### PR TITLE
Performance test for different types of Pixel structures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ tools/
 
 # Test results
 test_results/
+BenchmarkDotNet.Artifacts/
 
 # Documentation output
 docs/_site

--- a/.vscode/header-cs.code-snippets
+++ b/.vscode/header-cs.code-snippets
@@ -1,0 +1,33 @@
+{
+	"Header C#": {
+		"scope": "csharp",
+		"prefix": "header",
+		"description": "Insert the C# file header",
+		"body": [
+			"// Copyright (c) 2021 SceneGate",
+			"",
+			"// Permission is hereby granted, free of charge, to any person obtaining a copy",
+			"// of this software and associated documentation files (the \"Software\"), to deal",
+			"// in the Software without restriction, including without limitation the rights",
+			"// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell",
+			"// copies of the Software, and to permit persons to whom the Software is",
+			"// furnished to do so, subject to the following conditions:",
+			"",
+			"// The above copyright notice and this permission notice shall be included in all",
+			"// copies or substantial portions of the Software.",
+			"",
+			"// THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR",
+			"// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,",
+			"// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE",
+			"// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER",
+			"// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,",
+			"// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE",
+			"// SOFTWARE.",
+			"namespace ${1:SceneGate.Games.ProfessorLayton}",
+			"{",
+			"    $0",
+			"}",
+			""
+		]
+	}
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,4 +13,7 @@
         "editor.formatOnType": true
     },
     "prettier.proseWrap": "always",
+    "cSpell.words": [
+        "Texim"
+    ],
 }

--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -174,7 +174,7 @@ dotnet_diagnostic.SA1633.severity = none # No XML-format header in source files
 dotnet_diagnostic.S1135.severity = suggestion # It's almost inevitable to have TODO but add bug ID
 
 # Special rules for test projects
-[*Tests/**]
+[*Test/**]
 dotnet_diagnostic.CS1591.severity = none # Disable documentation
 dotnet_diagnostic.CA1001.severity = none # No need to implement IDisposable in test classes with cleanup.
 dotnet_diagnostic.CA1034.severity = none # Public types in test classes for testing implementations

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -4,6 +4,8 @@
         <PackageVersion Include="Yarhl" Version="3.0.0-alpha06" />
         <PackageVersion Include="System.Drawing.Common" Version="5.0.2" />
 
+        <PackageVersion Include="BenchmarkDotNet" Version="0.12.1" />
+
         <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.0.0" />
 
         <PackageVersion Include="StyleCop.Analyzers" Version="1.1.118" />

--- a/src/Texim.PerformanceTest/ImageStructures/Pixel.cs
+++ b/src/Texim.PerformanceTest/ImageStructures/Pixel.cs
@@ -1,0 +1,37 @@
+// Copyright (c) 2021 SceneGate
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+namespace Texim.PerformanceTest.ImageStructures
+{
+    public struct Pixel
+    {
+        public Pixel(int info, byte alpha, bool isIndexed)
+        {
+            IsIndexed = isIndexed;
+            Info = info;
+            Alpha = alpha;
+        }
+
+        public int Info { get; init; }
+
+        public bool IsIndexed { get; init; }
+
+        public byte Alpha { get; init; }
+    }
+}

--- a/src/Texim.PerformanceTest/ImageStructures/PixelRgb.cs
+++ b/src/Texim.PerformanceTest/ImageStructures/PixelRgb.cs
@@ -1,0 +1,56 @@
+// Copyright (c) 2021 SceneGate
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+namespace Texim.PerformanceTest.ImageStructures
+{
+    public struct PixelRgb
+    {
+        public PixelRgb(byte index, byte alpha)
+        {
+            IsIndexed = true;
+            Index = index;
+            Alpha = alpha;
+            Red = 0;
+            Green = 0;
+            Blue = 0;
+        }
+
+        public PixelRgb(byte red, byte green, byte blue, byte alpha)
+        {
+            IsIndexed = false;
+            Index = 0;
+            Alpha = alpha;
+            Red = red;
+            Green = green;
+            Blue = blue;
+        }
+
+        public bool IsIndexed { get; init; }
+
+        public byte Red { get; init; }
+
+        public byte Green { get; init; }
+
+        public byte Blue { get; init; }
+
+        public byte Index { get; init; }
+
+        public byte Alpha { get; init; }
+    }
+}

--- a/src/Texim.PerformanceTest/ImageStructures/StructureTest.cs
+++ b/src/Texim.PerformanceTest/ImageStructures/StructureTest.cs
@@ -1,0 +1,217 @@
+// Copyright (c) 2021 SceneGate
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+namespace Texim.PerformanceTest.ImageStructures
+{
+    using BenchmarkDotNet.Attributes;
+
+    [MemoryDiagnoser]
+    public class StructureTest
+    {
+        ushort[] colorBgr555;
+        byte[] index;
+
+        [Params(192 * 256, 4096 * 2160)]
+        public int Size { get; set; }
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            colorBgr555 = new ushort[] { 0xCAFE };
+            index = new byte[] { 0xCA, 0xFE };
+        }
+
+        [Benchmark]
+        public int SetPrimitiveIndexed()
+        {
+            var image = new uint[Size];
+            for (int i = 0; i < Size; i++) {
+                uint color = (uint)(index[0] | (index[1] << 24));
+                image[i] = color;
+            }
+
+            return -1;
+        }
+
+        [Benchmark]
+        public int SetPixelIndexed()
+        {
+            var image = new Pixel[Size];
+            for (int i = 0; i < Size; i++) {
+                var color = new Pixel(index[0], index[1], true);
+                image[i] = color;
+            }
+
+            return -1;
+        }
+
+        [Benchmark]
+        public int SetPixelRgbIndexed()
+        {
+            var image = new PixelRgb[Size];
+            for (int i = 0; i < Size; i++) {
+                var color = new PixelRgb(index[0], index[1]);
+                image[i] = color;
+            }
+
+            return -1;
+        }
+
+        [Benchmark]
+        public int SetPrimitiveColor()
+        {
+            var image = new uint[Size];
+            for (int i = 0; i < Size; i++) {
+                uint color = (uint)(
+                    ((colorBgr555[0] & 0xFF) << 3) |
+                    ((((colorBgr555[0] >> 5) & 0xFF) << 3) << 8) |
+                    ((((colorBgr555[0] >> 10) & 0xFF) << 3) << 16) |
+                    (((colorBgr555[0] >> 15) * 255) << 24));
+                image[i] = color;
+            }
+
+            return -1;
+        }
+
+        [Benchmark]
+        public int SetPixelColor()
+        {
+            var image = new Pixel[Size];
+            for (int i = 0; i < Size; i++) {
+                int info = (int)(
+                    ((colorBgr555[0] & 0xFF) << 3) |
+                    ((((colorBgr555[0] >> 5) & 0xFF) << 3) << 8) |
+                    ((((colorBgr555[0] >> 10) & 0xFF) << 3) << 16));
+                var color = new Pixel(info, (byte)((colorBgr555[0] >> 15) * 255), false);
+                image[i] = color;
+            }
+
+            return -1;
+        }
+
+        [Benchmark]
+        public int SetPixelRgbColor()
+        {
+            var image = new PixelRgb[Size];
+            for (int i = 0; i < Size; i++) {
+                var color = new PixelRgb(
+                    (byte)((colorBgr555[0] & 0xFF) << 3),
+                    (byte)(((colorBgr555[0] >> 5) & 0xFF) << 3),
+                    (byte)(((colorBgr555[0] >> 10) & 0xFF) << 3),
+                    (byte)((colorBgr555[0] >> 15) * 255));
+                image[i] = color;
+            }
+
+            return -1;
+        }
+
+        [Benchmark]
+        public int GetPrimitiveIndex()
+        {
+            int sum = 0;
+            var image = new uint[Size];
+            for (int i = 0; i < Size; i++) {
+                var pixel = image[i];
+                ushort color = (ushort)pixel;
+                sum += color;
+            }
+
+            return sum;
+        }
+
+        [Benchmark]
+        public int GetPixelIndex()
+        {
+            int sum = 0;
+            var image = new Pixel[Size];
+            for (int i = 0; i < Size; i++) {
+                var pixel = image[i];
+                ushort color = (ushort)pixel.Info;
+                sum += color;
+            }
+
+            return sum;
+        }
+
+        [Benchmark]
+        public int GetPixelRgbIndex()
+        {
+            int sum = 0;
+            var image = new PixelRgb[Size];
+            for (int i = 0; i < Size; i++) {
+                var pixel = image[i];
+                ushort color = pixel.Index;
+                sum += color;
+            }
+
+            return sum;
+        }
+
+        [Benchmark]
+        public int GetPrimitiveColor()
+        {
+            int sum = 0;
+            var image = new uint[Size];
+            for (int i = 0; i < Size; i++) {
+                var pixel = image[i];
+                ushort color = (ushort)(((pixel & 0xFF) >> 3)
+                    | ((((pixel >> 8) & 0xFF) >> 3) << 5)
+                    | ((((pixel >> 16) & 0xFF) >> 3) << 10)
+                    | (1 << 15));
+                sum += color;
+            }
+
+            return sum;
+        }
+
+        [Benchmark]
+        public int GetPixelColor()
+        {
+            int sum = 0;
+            var image = new Pixel[Size];
+            for (int i = 0; i < Size; i++) {
+                var pixel = image[i];
+                ushort color = (ushort)(((pixel.Info & 0xFF) >> 3)
+                    | ((((pixel.Info >> 8) & 0xFF) >> 3) << 5)
+                    | ((((pixel.Info >> 16) & 0xFF) >> 3) << 10)
+                    | (1 << 15));
+                sum += color;
+            }
+
+            return sum;
+        }
+
+        [Benchmark]
+        public int GetPixelRgbColor()
+        {
+            int sum = 0;
+            var image = new PixelRgb[Size];
+            for (int i = 0; i < Size; i++) {
+                var pixel = image[i];
+                ushort color = (ushort)((pixel.Red >> 3)
+                    | ((pixel.Green >> 3) << 5)
+                    | ((pixel.Blue >> 3) << 10)
+                    | (1 << 15));
+                sum += color;
+            }
+
+            return sum;
+        }
+    }
+}

--- a/src/Texim.PerformanceTest/Program.cs
+++ b/src/Texim.PerformanceTest/Program.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) 2021 SceneGate
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+namespace Texim.PerformanceTest
+{
+    using System;
+    using Texim.PerformanceTest.ImageStructures;
+
+    public static class Program
+    {
+        public static void Main(string[] args)
+        {
+            DisplaySizeOf<uint>();
+            DisplaySizeOf<Pixel>();
+            DisplaySizeOf<PixelRgb>();
+            BenchmarkDotNet.Running.BenchmarkRunner.Run<StructureTest>();
+        }
+
+        static unsafe void DisplaySizeOf<T>() where T : unmanaged
+        {
+            Console.WriteLine($"Size of {typeof(T)} is {sizeof(T)}");
+        }
+    }
+}

--- a/src/Texim.PerformanceTest/Texim.PerformanceTest.csproj
+++ b/src/Texim.PerformanceTest/Texim.PerformanceTest.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" />
+  </ItemGroup>
+
+</Project>

--- a/src/Texim.sln
+++ b/src/Texim.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Texim", "Texim\Texim.csproj
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Texim.Tool", "Texim.Tool\Texim.Tool.csproj", "{DC42B751-8302-400F-8528-9BB79DAE6B9D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Texim.PerformanceTest", "Texim.PerformanceTest\Texim.PerformanceTest.csproj", "{748619CD-2836-4E4C-BAD7-DD000737D0E6}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -44,5 +46,17 @@ Global
 		{DC42B751-8302-400F-8528-9BB79DAE6B9D}.Release|x64.Build.0 = Release|Any CPU
 		{DC42B751-8302-400F-8528-9BB79DAE6B9D}.Release|x86.ActiveCfg = Release|Any CPU
 		{DC42B751-8302-400F-8528-9BB79DAE6B9D}.Release|x86.Build.0 = Release|Any CPU
+		{748619CD-2836-4E4C-BAD7-DD000737D0E6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{748619CD-2836-4E4C-BAD7-DD000737D0E6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{748619CD-2836-4E4C-BAD7-DD000737D0E6}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{748619CD-2836-4E4C-BAD7-DD000737D0E6}.Debug|x64.Build.0 = Debug|Any CPU
+		{748619CD-2836-4E4C-BAD7-DD000737D0E6}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{748619CD-2836-4E4C-BAD7-DD000737D0E6}.Debug|x86.Build.0 = Debug|Any CPU
+		{748619CD-2836-4E4C-BAD7-DD000737D0E6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{748619CD-2836-4E4C-BAD7-DD000737D0E6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{748619CD-2836-4E4C-BAD7-DD000737D0E6}.Release|x64.ActiveCfg = Release|Any CPU
+		{748619CD-2836-4E4C-BAD7-DD000737D0E6}.Release|x64.Build.0 = Release|Any CPU
+		{748619CD-2836-4E4C-BAD7-DD000737D0E6}.Release|x86.ActiveCfg = Release|Any CPU
+		{748619CD-2836-4E4C-BAD7-DD000737D0E6}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
### Description

Perform a performance test to evaluate different implementations of the elements (Pixel) of an image. The options were:

- `uint` that represents a 24-bits color or the color table index + 8-bits for alpha
  - Size: 4 bytes
- `Pixel` struct that separates the alpha channel and has a boolean to indicate if it's indexed or not.
  - Size: 8 bytes
- `PixelRgb` with a field per color channel and alpha.
  - Size: 6 bytes

``` ini

BenchmarkDotNet=v0.12.1, OS=ubuntu 20.04 (container)
Intel Core i7-4720HQ CPU 2.60GHz (Haswell), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=5.0.201
  [Host]     : .NET Core 5.0.4 (CoreCLR 5.0.421.11614, CoreFX 5.0.421.11614), X64 RyuJIT
  DefaultJob : .NET Core 5.0.4 (CoreCLR 5.0.421.11614, CoreFX 5.0.421.11614), X64 RyuJIT


```
|              Method |    Size |         Mean |      Error |     StdDev |    Gen 0 |    Gen 1 |    Gen 2 |   Allocated |
|-------------------- |-------- |-------------:|-----------:|-----------:|---------:|---------:|---------:|------------:|
| SetPrimitiveIndexed |   49152 |    124.37 μs |   0.632 μs |   0.560 μs |  62.2559 |  62.2559 |  62.2559 |   192.04 KB |
|     SetPixelIndexed |   49152 |    199.56 μs |   0.932 μs |   0.826 μs | 124.7559 | 124.7559 | 124.7559 |   384.06 KB |
|  SetPixelRgbIndexed |   49152 |    461.56 μs |   1.033 μs |   0.916 μs |  90.8203 |  90.8203 |  90.8203 |   288.05 KB |
|   SetPrimitiveColor |   49152 |    169.70 μs |   0.536 μs |   0.475 μs |  62.2559 |  62.2559 |  62.2559 |   192.04 KB |
|       SetPixelColor |   49152 |    259.35 μs |   1.615 μs |   1.432 μs | 124.5117 | 124.5117 | 124.5117 |   384.06 KB |
|    SetPixelRgbColor |   49152 |    505.18 μs |   1.663 μs |   1.474 μs |  90.8203 |  90.8203 |  90.8203 |   288.05 KB |
|   GetPrimitiveIndex |   49152 |     68.94 μs |   0.500 μs |   0.418 μs |  62.3779 |  62.3779 |  62.3779 |   192.04 KB |
|       GetPixelIndex |   49152 |    129.67 μs |   0.833 μs |   0.779 μs | 124.7559 | 124.7559 | 124.7559 |   384.06 KB |
|    GetPixelRgbIndex |   49152 |    115.20 μs |   0.787 μs |   0.698 μs |  90.8203 |  90.8203 |  90.8203 |   288.05 KB |
|   GetPrimitiveColor |   49152 |    137.52 μs |   0.594 μs |   0.555 μs |  62.2559 |  62.2559 |  62.2559 |   192.04 KB |
|       GetPixelColor |   49152 |    193.40 μs |   1.390 μs |   1.233 μs | 124.7559 | 124.7559 | 124.7559 |   384.06 KB |
|    GetPixelRgbColor |   49152 |    173.60 μs |   1.320 μs |   1.170 μs |  90.8203 |  90.8203 |  90.8203 |   288.05 KB |
| SetPrimitiveIndexed | 8847360 | 22,212.99 μs | 404.346 μs | 378.225 μs | 968.7500 | 968.7500 | 968.7500 |  34560.3 KB |
|     SetPixelIndexed | 8847360 | 36,111.93 μs | 456.344 μs | 404.537 μs | 928.5714 | 928.5714 | 928.5714 |  69120.3 KB |
|  SetPixelRgbIndexed | 8847360 | 82,676.19 μs | 632.159 μs | 591.322 μs | 833.3333 | 833.3333 | 833.3333 |    51841 KB |
|   SetPrimitiveColor | 8847360 | 30,725.33 μs | 450.606 μs | 399.451 μs | 968.7500 | 968.7500 | 968.7500 |  34560.3 KB |
|       SetPixelColor | 8847360 | 47,022.38 μs | 486.220 μs | 406.016 μs | 909.0909 | 909.0909 | 909.0909 | 69121.11 KB |
|    SetPixelRgbColor | 8847360 | 90,049.44 μs | 442.200 μs | 413.634 μs | 833.3333 | 833.3333 | 833.3333 |    51841 KB |
|   GetPrimitiveIndex | 8847360 | 10,812.43 μs | 107.532 μs |  95.324 μs | 984.3750 | 984.3750 | 984.3750 |  34560.3 KB |
|       GetPixelIndex | 8847360 | 20,093.64 μs | 166.288 μs | 155.546 μs | 968.7500 | 968.7500 | 968.7500 |  69120.3 KB |
|    GetPixelRgbIndex | 8847360 | 18,418.86 μs | 103.715 μs |  91.941 μs | 968.7500 | 968.7500 | 968.7500 |  51840.3 KB |
|   GetPrimitiveColor | 8847360 | 23,057.97 μs | 129.346 μs | 114.662 μs | 968.7500 | 968.7500 | 968.7500 |  34560.3 KB |
|       GetPixelColor | 8847360 | 31,531.98 μs | 189.125 μs | 176.908 μs | 937.5000 | 937.5000 | 937.5000 |  69120.3 KB |
|    GetPixelRgbColor | 8847360 | 28,801.54 μs | 137.747 μs | 115.025 μs | 968.7500 | 968.7500 | 968.7500 |  51840.3 KB |


## Conclusion

Even with an 4k image it takes just 28 ms to read and 47 ms to write with the structure `PixelRgb`. As that structure is easier to work with and the time is quite fast it will be the option to go. The size of an image would be 6 times bytes the number of pixels. For a 4k image it would be 50 MB. For a NDS image it would be 288 KB. By reusing buffers this would be acceptable.