### PR TITLE
Implement color quantization API, algorithms and importers

### DIFF
--- a/src/Texim/Colors/Rgb.cs
+++ b/src/Texim/Colors/Rgb.cs
@@ -23,6 +23,14 @@ namespace Texim.Colors
 
     public readonly struct Rgb
     {
+        public Rgb(Color color)
+        {
+            Alpha = color.A;
+            Red = color.R;
+            Green = color.G;
+            Blue = color.B;
+        }
+
         public Rgb(Rgb color, byte alpha)
         {
             Alpha = alpha;

--- a/src/Texim/Colors/Rgb.cs
+++ b/src/Texim/Colors/Rgb.cs
@@ -56,5 +56,12 @@ namespace Texim.Colors
         public byte Alpha { get; init; }
 
         public readonly Color ToColor() => Color.FromArgb(Alpha, Red, Green, Blue);
+
+        public readonly double GetDistanceSquared(Rgb other)
+        {
+            return ((Red - other.Red) * (Red - other.Red))
+                + ((Green - other.Green) * (Green - other.Green))
+                + ((Blue - other.Blue) * (Blue - other.Blue));
+        }
     }
 }

--- a/src/Texim/Formats/Bitmap2FullImage.cs
+++ b/src/Texim/Formats/Bitmap2FullImage.cs
@@ -1,0 +1,48 @@
+// Copyright (c) 2021 SceneGate
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+namespace Texim.Formats
+{
+    using System;
+    using System.Drawing;
+    using Texim.Colors;
+    using Texim.Images;
+    using Yarhl.FileFormat;
+    using Yarhl.IO;
+
+    public class Bitmap2FullImage : IConverter<BinaryFormat, FullImage>
+    {
+        public FullImage Convert(BinaryFormat source)
+        {
+            if (source == null)
+                throw new ArgumentNullException(nameof(source));
+
+            using var image = (Bitmap)Image.FromStream(source.Stream);
+            var fullImage = new FullImage(image.Width, image.Height);
+
+            for (int x = 0; x < image.Width; x++) {
+                for (int y = 0; y < image.Height; y++) {
+                    fullImage.Pixels[(y * image.Width) + x] = new Rgb(image.GetPixel(x, y));
+                }
+            }
+
+            return fullImage;
+        }
+    }
+}

--- a/src/Texim/Images/FullImage2IndexedPalette.cs
+++ b/src/Texim/Images/FullImage2IndexedPalette.cs
@@ -1,0 +1,55 @@
+// Copyright (c) 2021 SceneGate
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+namespace Texim.Images
+{
+    using System;
+    using Texim.Palettes;
+    using Texim.Pixels;
+    using Texim.Processing;
+    using Yarhl.FileFormat;
+
+    public class FullImage2IndexedPalette :
+        IInitializer<IQuantization>, IConverter<IFullImage, IndexedPaletteImage>
+    {
+        private IQuantization quantization;
+
+        public void Initialize(IQuantization parameters)
+        {
+            quantization = parameters ?? throw new ArgumentNullException(nameof(parameters));
+        }
+
+        public IndexedPaletteImage Convert(IFullImage source)
+        {
+            if (source == null)
+                throw new ArgumentNullException(nameof(source));
+
+            (IndexedPixel[] pixels, IPaletteCollection palette) = quantization.Quantize(source.Pixels);
+
+            var indexed = new IndexedPaletteImage {
+                Width = source.Width,
+                Height = source.Height,
+                Pixels = pixels,
+            };
+            indexed.Palettes.Add(palette.Palettes);
+
+            return indexed;
+        }
+    }
+}

--- a/src/Texim/Images/IndexedPaletteImage.cs
+++ b/src/Texim/Images/IndexedPaletteImage.cs
@@ -1,0 +1,44 @@
+// Copyright (c) 2021 SceneGate
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+namespace Texim.Images
+{
+    using System.Collections.ObjectModel;
+    using Texim.Palettes;
+    using Texim.Pixels;
+
+    public class IndexedPaletteImage : IIndexedImage, IPaletteCollection
+    {
+        private static Indexed2FullImage fullImageConverter = new Indexed2FullImage();
+
+        public int Width { get; init; }
+
+        public int Height { get; init; }
+
+        public IndexedPixel[] Pixels { get; init; }
+
+        public Collection<IPalette> Palettes { get; } = new Collection<IPalette>();
+
+        public FullImage CreateFullImage()
+        {
+            fullImageConverter.Initialize(this);
+            return fullImageConverter.Convert(this);
+        }
+    }
+}

--- a/src/Texim/Processing/ExhaustiveColorSearch.cs
+++ b/src/Texim/Processing/ExhaustiveColorSearch.cs
@@ -17,29 +17,40 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
-namespace Texim.Palettes
+namespace Texim.Processing
 {
     using System.Collections.Generic;
-    using System.Collections.ObjectModel;
     using System.Linq;
+    using Texim.Colors;
 
-    public class PaletteCollection : IPaletteCollection
+    public class ExhaustiveColorSearch
     {
-        public PaletteCollection()
+        private readonly Rgb[] vertex;
+
+        public ExhaustiveColorSearch(IEnumerable<Rgb> vertex)
         {
-            Palettes = new Collection<IPalette>();
+            this.vertex = vertex.ToArray();
         }
 
-        public PaletteCollection(IPalette initialPalette)
+        public int Search(Rgb color)
         {
-            Palettes = new Collection<IPalette> { initialPalette };
-        }
+            // Set the largest distance and a null index
+            double minDistance = (255 * 255) + (255 * 255) + (255 * 255) + 1;
+            int nearestColor = -1;
 
-        public PaletteCollection(IEnumerable<IPalette> initialPalettes)
-        {
-            Palettes = new Collection<IPalette>(initialPalettes.ToList());
-        }
+            // FUTURE: Implement "Approximate Nearest Neighbors in Non-Euclidean Spaces"
+            // algorithm or k-d tree if it's computing CIE76 color difference
+            for (int i = 0; i < vertex.Length && minDistance > 0; i++) {
+                // Since we only want the value to compare,
+                // it is faster to not computer the squared root
+                double distance = color.GetDistanceSquared(this.vertex[i]);
+                if (distance < minDistance) {
+                    minDistance = distance;
+                    nearestColor = i;
+                }
+            }
 
-        public Collection<IPalette> Palettes { get; }
+            return nearestColor;
+        }
     }
 }

--- a/src/Texim/Processing/FixedPaletteQuantization.cs
+++ b/src/Texim/Processing/FixedPaletteQuantization.cs
@@ -1,0 +1,54 @@
+// Copyright (c) 2021 SceneGate
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+namespace Texim.Processing
+{
+    using Texim.Colors;
+    using Texim.Palettes;
+    using Texim.Pixels;
+
+    public class FixedPaletteQuantization : IQuantization
+    {
+        private readonly IPalette palette;
+        private readonly ExhaustiveColorSearch search;
+
+        public FixedPaletteQuantization(IPalette palette)
+        {
+            this.palette = palette;
+            search = new ExhaustiveColorSearch(palette.Colors);
+        }
+
+        public bool FirstAsTransparent { get; set; }
+
+        public (IndexedPixel[], IPaletteCollection) Quantize(Rgb[] pixels)
+        {
+            var indexed = new IndexedPixel[pixels.Length];
+
+            for (int i = 0; i < pixels.Length; i++) {
+                int colorIdx = (FirstAsTransparent && pixels[i].Alpha >= 128)
+                    ? 0
+                    : search.Search(pixels[i]);
+                indexed[i] = new IndexedPixel((short)colorIdx, pixels[i].Alpha, 0);
+            }
+
+            var collection = new PaletteCollection(palette);
+            return (indexed, collection);
+        }
+    }
+}

--- a/src/Texim/Processing/IQuantization.cs
+++ b/src/Texim/Processing/IQuantization.cs
@@ -17,29 +17,14 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
-namespace Texim.Palettes
+namespace Texim.Processing
 {
-    using System.Collections.Generic;
-    using System.Collections.ObjectModel;
-    using System.Linq;
+    using Texim.Colors;
+    using Texim.Palettes;
+    using Texim.Pixels;
 
-    public class PaletteCollection : IPaletteCollection
+    public interface IQuantization
     {
-        public PaletteCollection()
-        {
-            Palettes = new Collection<IPalette>();
-        }
-
-        public PaletteCollection(IPalette initialPalette)
-        {
-            Palettes = new Collection<IPalette> { initialPalette };
-        }
-
-        public PaletteCollection(IEnumerable<IPalette> initialPalettes)
-        {
-            Palettes = new Collection<IPalette>(initialPalettes.ToList());
-        }
-
-        public Collection<IPalette> Palettes { get; }
+        (IndexedPixel[], IPaletteCollection) Quantize(Rgb[] pixels);
     }
 }

--- a/src/Texim/Processing/MedianCutQuantization.cs
+++ b/src/Texim/Processing/MedianCutQuantization.cs
@@ -1,0 +1,111 @@
+// Copyright (c) 2021 SceneGate
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+namespace Texim.Processing
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Texim.Colors;
+    using Texim.Palettes;
+    using Texim.Pixels;
+
+    public class MedianCutQuantization : IQuantization
+    {
+        public MedianCutQuantization(int maxColors)
+        {
+            if (maxColors <= 0)
+                throw new ArgumentOutOfRangeException(nameof(maxColors), maxColors, "Cannot be less than 0");
+            if ((maxColors & (maxColors - 1)) != 0)
+                throw new ArgumentOutOfRangeException(nameof(maxColors), maxColors, "Must be power of 2");
+
+            MaxColors = maxColors;
+        }
+
+        public int MaxColors { get; }
+
+        public (IndexedPixel[], IPaletteCollection) Quantize(Rgb[] pixels)
+        {
+            // Convert to pixel reference to keep track of pixel indexes
+            var pixelrefs = new PixelRef[pixels.Length];
+            for (int i = 0; i < pixels.Length; i++) {
+                pixelrefs[i] = new PixelRef(pixels[i], i);
+            }
+
+            // Initialize with all colors in a bucket.
+            var buckets = new Queue<PixelRef[]>();
+            buckets.Enqueue(pixelrefs);
+
+            // Median cut until we have a bucket per palette color
+            while (buckets.Count < MaxColors) {
+                PixelRef[] bucket = buckets.Dequeue();
+                var (bucket1, bucket2) = MedianCut(bucket);
+            }
+
+            // Average bucket color and create indexes
+            var indexed = new IndexedPixel[pixels.Length];
+            var palette = new Palette();
+            foreach (PixelRef[] bucket in buckets) {
+                Rgb color = Average(bucket);
+
+                short paletteIdx = (short)palette.Colors.Count;
+                palette.Colors.Add(color);
+
+                foreach (PixelRef pixel in bucket) {
+                    indexed[pixel.Index] = new IndexedPixel(paletteIdx);
+                }
+            }
+
+            return (indexed, new PaletteCollection(palette));
+        }
+
+        private (PixelRef[], PixelRef[]) MedianCut(PixelRef[] bucket)
+        {
+            long rangeRed = bucket.Max(c => c.Color.Red) - bucket.Min(c => c.Color.Red);
+            long rangeGreen = bucket.Max(c => c.Color.Green) - bucket.Min(c => c.Color.Green);
+            long rangeBlue = bucket.Max(c => c.Color.Blue) - bucket.Min(c => c.Color.Blue);
+
+            PixelRef[] sorted;
+            if (rangeRed >= rangeGreen && rangeRed >= rangeBlue) {
+                sorted = bucket.OrderBy(c => c.Color.Red).ToArray();
+            } else if (rangeGreen >= rangeRed && rangeGreen >= rangeBlue) {
+                sorted = bucket.OrderBy(c => c.Color.Green).ToArray();
+            } else {
+                sorted = bucket.OrderBy(c => c.Color.Blue).ToArray();
+            }
+
+            int median = bucket.Length / 2;
+            return (sorted[..median], sorted[median..]);
+        }
+
+        private Rgb Average(PixelRef[] bucket) =>
+            new Rgb((byte)bucket.Average(c => c.Color.Red),
+                (byte)bucket.Average(c => c.Color.Green),
+                (byte)bucket.Average(c => c.Color.Blue));
+
+        private readonly struct PixelRef
+        {
+            public PixelRef(Rgb color, int index) => (Color, Index) = (color, index);
+
+            public Rgb Color { get; init; }
+
+            public int Index { get; init; }
+        }
+    }
+}

--- a/src/Texim/Processing/MedianCutQuantization.cs
+++ b/src/Texim/Processing/MedianCutQuantization.cs
@@ -56,6 +56,8 @@ namespace Texim.Processing
             while (buckets.Count < MaxColors) {
                 PixelRef[] bucket = buckets.Dequeue();
                 var (bucket1, bucket2) = MedianCut(bucket);
+                buckets.Enqueue(bucket1);
+                buckets.Enqueue(bucket2);
             }
 
             // Average bucket color and create indexes
@@ -95,7 +97,8 @@ namespace Texim.Processing
         }
 
         private Rgb Average(PixelRef[] bucket) =>
-            new Rgb((byte)bucket.Average(c => c.Color.Red),
+            new Rgb(
+                (byte)bucket.Average(c => c.Color.Red),
                 (byte)bucket.Average(c => c.Color.Green),
                 (byte)bucket.Average(c => c.Color.Blue));
 

--- a/src/Texim/Processing/Quantization.cs
+++ b/src/Texim/Processing/Quantization.cs
@@ -1,0 +1,60 @@
+// Copyright (c) 2021 SceneGate
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+namespace Texim.Processing
+{
+    using Texim.Colors;
+    using Texim.Palettes;
+    using Texim.Pixels;
+
+    public class Quantization : IQuantization
+    {
+        public bool FirstAsTransparent { get; set; }
+
+        public Rgb AlphaColor { get; set; }
+
+        public (IndexedPixel[], IPaletteCollection) Quantize(Rgb[] pixels)
+        {
+            var indexed = new IndexedPixel[pixels.Length];
+            var palette = new Palette();
+
+            if (FirstAsTransparent) {
+                palette.Colors.Add(AlphaColor);
+            }
+
+            for (int i = 0; i < pixels.Length; i++) {
+                if (FirstAsTransparent && pixels[i].Alpha >= 128) {
+                    indexed[i] = new IndexedPixel(0, pixels[i].Alpha, 0);
+                    continue;
+                }
+
+                int colorIdx = palette.Colors.IndexOf(pixels[i]);
+                if (colorIdx == -1) {
+                    colorIdx = palette.Colors.Count;
+                    palette.Colors.Add(pixels[i]);
+                }
+
+                indexed[i] = new IndexedPixel((short)colorIdx, pixels[i].Alpha, 0);
+            }
+
+            var collection = new PaletteCollection(palette);
+            return (indexed, collection);
+        }
+    }
+}


### PR DESCRIPTION
### Description

Implement a new API for color quantization with the interface `IQuantization`. Add the implementation for a basic (`Quantization`), fixed palette (`FixedPaletteQuantization`) and median cut (`MedianCutQuantization`) algorithms.

Implement converters to be able to convert a regular bitmap image into an indexed format with: `Bitmap2FullImage` and `FullImage2IndexedPalette`. Add a new type that holds a palette and indexed pixels: `IndexedPaletteImage`.
