### PR TITLE
Implement Nitro tile compression via map/screen data

### DIFF
--- a/src/Texim.Tool/Nitro/NitroBackgroundMode.cs
+++ b/src/Texim.Tool/Nitro/NitroBackgroundMode.cs
@@ -17,40 +17,12 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
-namespace Texim.Compressions.Nitro
+namespace Texim.Tool.Nitro
 {
-    public readonly struct MapInfo
+    public enum NitroBackgroundMode
     {
-        public MapInfo(byte value)
-        {
-            TileIndex = value;
-            HorizontalFlip = false;
-            VerticalFlip = false;
-            PaletteIndex = 0;
-        }
-
-        public MapInfo(short value)
-        {
-            TileIndex = (short)(value & 0x3FF);
-            HorizontalFlip = (value >> 10) == 1;
-            VerticalFlip = (value >> 11) == 1;
-            PaletteIndex = (byte)(value >> 12);
-        }
-
-        public short TileIndex { get; init; }
-
-        public bool HorizontalFlip { get; init; }
-
-        public bool VerticalFlip { get; init; }
-
-        public byte PaletteIndex { get; init; }
-
-        public readonly short ToInt16()
-        {
-            return (short)((TileIndex & 0x3FF)
-                | ((HorizontalFlip ? 1 : 0) << 10)
-                | ((VerticalFlip ? 1 : 0) << 11)
-                | ((PaletteIndex & 0x0F) << 12));
-        }
+        Text = 0,
+        Affine = 1, // Palette must be 8bpp
+        Extended = 2, // Extended mode -> Text | Affine, not bitmap
     }
 }

--- a/src/Texim.Tool/Nitro/NitroPaletteMode.cs
+++ b/src/Texim.Tool/Nitro/NitroPaletteMode.cs
@@ -17,40 +17,12 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
-namespace Texim.Compressions.Nitro
+namespace Texim.Tool.Nitro
 {
-    public readonly struct MapInfo
+    public enum NitroPaletteMode
     {
-        public MapInfo(byte value)
-        {
-            TileIndex = value;
-            HorizontalFlip = false;
-            VerticalFlip = false;
-            PaletteIndex = 0;
-        }
-
-        public MapInfo(short value)
-        {
-            TileIndex = (short)(value & 0x3FF);
-            HorizontalFlip = (value >> 10) == 1;
-            VerticalFlip = (value >> 11) == 1;
-            PaletteIndex = (byte)(value >> 12);
-        }
-
-        public short TileIndex { get; init; }
-
-        public bool HorizontalFlip { get; init; }
-
-        public bool VerticalFlip { get; init; }
-
-        public byte PaletteIndex { get; init; }
-
-        public readonly short ToInt16()
-        {
-            return (short)((TileIndex & 0x3FF)
-                | ((HorizontalFlip ? 1 : 0) << 10)
-                | ((VerticalFlip ? 1 : 0) << 11)
-                | ((PaletteIndex & 0x0F) << 12));
-        }
+        Palette16x16 = 0, // 16 colors / 16 palettes
+        Palette256x1 = 1, // 256 colors / 1 palette
+        Extended = 2, // 256 colors / 16 palettes
     }
 }

--- a/src/Texim.Tool/Nitro/Nscr.cs
+++ b/src/Texim.Tool/Nitro/Nscr.cs
@@ -17,40 +17,25 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
-namespace Texim.Compressions.Nitro
+namespace Texim.Tool.Nitro
 {
-    public readonly struct MapInfo
+    using System;
+    using Texim.Compressions.Nitro;
+
+    public class Nscr : IScreenMap, INitroFormat
     {
-        public MapInfo(byte value)
-        {
-            TileIndex = value;
-            HorizontalFlip = false;
-            VerticalFlip = false;
-            PaletteIndex = 0;
-        }
+        public string Stamp => "NSCR";
 
-        public MapInfo(short value)
-        {
-            TileIndex = (short)(value & 0x3FF);
-            HorizontalFlip = (value >> 10) == 1;
-            VerticalFlip = (value >> 11) == 1;
-            PaletteIndex = (byte)(value >> 12);
-        }
+        public Version Version { get; set; }
 
-        public short TileIndex { get; init; }
+        public MapInfo[] Maps { get; set; }
 
-        public bool HorizontalFlip { get; init; }
+        public int Width { get; set; }
 
-        public bool VerticalFlip { get; init; }
+        public int Height { get; set; }
 
-        public byte PaletteIndex { get; init; }
+        public NitroPaletteMode PaletteMode { get; set; }
 
-        public readonly short ToInt16()
-        {
-            return (short)((TileIndex & 0x3FF)
-                | ((HorizontalFlip ? 1 : 0) << 10)
-                | ((VerticalFlip ? 1 : 0) << 11)
-                | ((PaletteIndex & 0x0F) << 12));
-        }
+        public NitroBackgroundMode BackgroundMode { get; set; }
     }
 }

--- a/src/Texim/Compressions/Nitro/IOExtensions.cs
+++ b/src/Texim/Compressions/Nitro/IOExtensions.cs
@@ -1,0 +1,54 @@
+// Copyright (c) 2021 SceneGate
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+namespace Texim.Compressions.Nitro
+{
+    using System.Collections.Generic;
+    using Yarhl.IO;
+
+    public static class IOExtensions
+    {
+        public static MapInfo ReadMapInfo(this DataReader reader)
+        {
+            return new MapInfo(reader.ReadInt16());
+        }
+
+        public static MapInfo[] ReadMapInfos(this DataReader reader, int numMaps)
+        {
+            var infos = new MapInfo[numMaps];
+            for (int i = 0; i < numMaps; i++) {
+                infos[i] = new MapInfo(reader.ReadInt16());
+            }
+
+            return infos;
+        }
+
+        public static void Write(this DataWriter writer, MapInfo info)
+        {
+            writer.Write(info.ToInt16());
+        }
+
+        public static void Write(this DataWriter writer, IEnumerable<MapInfo> infos)
+        {
+            foreach (var info in infos) {
+                writer.Write(info.ToInt16());
+            }
+        }
+    }
+}

--- a/src/Texim/Compressions/Nitro/IScreenMap.cs
+++ b/src/Texim/Compressions/Nitro/IScreenMap.cs
@@ -1,0 +1,32 @@
+// Copyright (c) 2021 SceneGate
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+namespace Texim.Compressions.Nitro
+{
+    using Yarhl.FileFormat;
+
+    public interface IScreenMap : IFormat
+    {
+        MapInfo[] Maps { get; }
+
+        int Width { get; }
+
+        int Height { get; }
+    }
+}

--- a/src/Texim/Compressions/Nitro/IndexedMapImage.cs
+++ b/src/Texim/Compressions/Nitro/IndexedMapImage.cs
@@ -1,0 +1,35 @@
+// Copyright (c) 2021 SceneGate
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+namespace Texim.Compressions.Nitro
+{
+    using Texim.Images;
+    using Texim.Pixels;
+
+    public class IndexedMapImage : IScreenMap, IIndexedImage
+    {
+        public int Width { get; init; }
+
+        public int Height { get; init; }
+
+        public MapInfo[] Maps { get; init; }
+
+        public IndexedPixel[] Pixels { get; init; }
+    }
+}

--- a/src/Texim/Compressions/Nitro/MapCompression.cs
+++ b/src/Texim/Compressions/Nitro/MapCompression.cs
@@ -1,0 +1,122 @@
+// Copyright (c) 2021 SceneGate
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+namespace Texim.Compressions.Nitro
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Drawing;
+    using System.Linq;
+    using Texim.Images;
+    using Texim.Pixels;
+    using Yarhl.FileFormat;
+
+    public class MapCompression :
+        IInitializer<Size>, IConverter<IIndexedImage, IndexedMapImage>
+    {
+        private Size tileSize = new Size(8, 8);
+
+        public void Initialize(Size parameters) => tileSize = parameters;
+
+        public IndexedMapImage Convert(IIndexedImage source)
+        {
+            if (source == null)
+                throw new ArgumentNullException(nameof(source));
+
+            // First we need to do tile swizzling
+            var swizzling = new TileSwizzling<IndexedPixel>(source.Width);
+            var tiles = swizzling.Swizzle(source.Pixels).AsMemory();
+
+            int pixelsPerTile = tileSize.Width * tileSize.Height;
+            int numTiles = tiles.Length / pixelsPerTile;
+            var uniqueTiles = new List<Memory<IndexedPixel>>();
+            var maps = new MapInfo[numTiles];
+
+            for (int i = 0; i < numTiles; i++) {
+                var tile = tiles.Slice(i * pixelsPerTile, pixelsPerTile);
+
+                int repeatedIdx = uniqueTiles.FindIndex(t => t.HasEquivalentIndexes(tile));
+                if (repeatedIdx != -1) {
+                    maps[i] = new MapInfo {
+                        TileIndex = (short)repeatedIdx,
+                        HorizontalFlip = false,
+                        VerticalFlip = false,
+                        PaletteIndex = tile.Span[0].PaletteIndex,
+                    };
+                    continue;
+                }
+
+                tile.FlipHorizontal(tileSize);
+                repeatedIdx = uniqueTiles.FindIndex(t => t.HasEquivalentIndexes(tile));
+                if (repeatedIdx != -1) {
+                    maps[i] = new MapInfo {
+                        TileIndex = (short)repeatedIdx,
+                        HorizontalFlip = true,
+                        VerticalFlip = false,
+                        PaletteIndex = tile.Span[0].PaletteIndex,
+                    };
+                    continue;
+                }
+
+                tile.FlipVertical(tileSize);
+                repeatedIdx = uniqueTiles.FindIndex(t => t.HasEquivalentIndexes(tile));
+                if (repeatedIdx != -1) {
+                    maps[i] = new MapInfo {
+                        TileIndex = (short)repeatedIdx,
+                        HorizontalFlip = true,
+                        VerticalFlip = true,
+                        PaletteIndex = tile.Span[0].PaletteIndex,
+                    };
+                    continue;
+                }
+
+                tile.FlipHorizontal(tileSize);
+                repeatedIdx = uniqueTiles.FindIndex(t => t.HasEquivalentIndexes(tile));
+                if (repeatedIdx != -1) {
+                    maps[i] = new MapInfo {
+                        TileIndex = (short)repeatedIdx,
+                        HorizontalFlip = false,
+                        VerticalFlip = true,
+                        PaletteIndex = tile.Span[0].PaletteIndex,
+                    };
+                    continue;
+                }
+
+                tile.FlipVertical(tileSize);
+                maps[i] = new MapInfo {
+                    TileIndex = (short)uniqueTiles.Count,
+                    HorizontalFlip = false,
+                    VerticalFlip = false,
+                    PaletteIndex = tile.Span[0].PaletteIndex,
+                };
+                uniqueTiles.Add(tile);
+            }
+
+            var uniquePixels = uniqueTiles.SelectMany(t => t.ToArray()).ToArray();
+            uniquePixels = swizzling.Unswizzle(uniquePixels);
+
+            return new IndexedMapImage {
+                Width = source.Width,
+                Height = source.Height,
+                Maps = maps,
+                Pixels = uniquePixels,
+            };
+        }
+    }
+}

--- a/src/Texim/Compressions/Nitro/MapDecompression.cs
+++ b/src/Texim/Compressions/Nitro/MapDecompression.cs
@@ -1,0 +1,136 @@
+// Copyright (c) 2021 SceneGate
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+namespace Texim.Compressions.Nitro
+{
+    using System;
+    using System.Drawing;
+    using Texim.Images;
+    using Texim.Pixels;
+    using Yarhl.FileFormat;
+
+    public class MapDecompression :
+        IInitializer<MapDecompressionParameters>,
+        IConverter<IIndexedImage, IndexedImage>,
+        IConverter<IndexedPixel[], IndexedPixel[]>
+    {
+        private Size tileSize;
+        private IScreenMap map;
+
+        public void Initialize(MapDecompressionParameters parameters)
+        {
+            if (parameters == null)
+                throw new ArgumentNullException(nameof(parameters));
+
+            tileSize = parameters.TileSize;
+            map = parameters.Map;
+        }
+
+        public IndexedImage Convert(IIndexedImage source)
+        {
+            if (source == null)
+                throw new ArgumentNullException(nameof(source));
+            if (map == null)
+                throw new InvalidOperationException("Missing initialization");
+
+            // It's easier if we swizzle again
+            var swizzling = new TileSwizzling<IndexedPixel>(source.Width);
+            IndexedPixel[] tiles = swizzling.Swizzle(source.Pixels);
+
+            IndexedPixel[] decompressed = DecompressTiles(tiles);
+            decompressed = swizzling.Unswizzle(decompressed);
+
+            return new IndexedImage(map.Width, map.Height, decompressed);
+        }
+
+        public IndexedPixel[] Convert(IndexedPixel[] source)
+        {
+            if (source == null)
+                throw new ArgumentNullException(nameof(source));
+            if (map == null)
+                throw new InvalidOperationException("Missing initialization");
+
+            return DecompressTiles(source);
+        }
+
+        private IndexedPixel[] DecompressTiles(IndexedPixel[] source)
+        {
+            int pixelsPerTile = tileSize.Width * tileSize.Height;
+
+            var decompressed = new IndexedPixel[map.Width * map.Height];
+            Span<IndexedPixel> pixelsOut = decompressed;
+            Span<IndexedPixel> pixelsIn = source;
+
+            for (int i = 0; i < map.Maps.Length; i++) {
+                MapInfo info = map.Maps[i];
+
+                int inIndex = info.TileIndex * pixelsPerTile;
+                Span<IndexedPixel> tileIn = pixelsIn.Slice(inIndex, pixelsPerTile);
+
+                int outIndex = i * pixelsPerTile;
+                Span<IndexedPixel> tileOut = pixelsOut.Slice(outIndex, pixelsPerTile);
+
+                for (int t = 0; t < pixelsPerTile; t++) {
+                    tileOut[t] = new IndexedPixel(
+                        tileIn[t].Index,
+                        tileIn[t].Alpha,
+                        info.PaletteIndex);
+                }
+
+                if (info.HorizontalFlip) {
+                    FlipHorizontal(tileOut);
+                }
+
+                if (info.VerticalFlip) {
+                    FlipVertical(tileOut);
+                }
+            }
+
+            return decompressed;
+        }
+
+        private void FlipHorizontal(Span<IndexedPixel> tile)
+        {
+            for (int y = 0; y < tileSize.Height; y++) {
+                for (int x = 0; x < tileSize.Width / 2; x++) {
+                    int t1 = y * tileSize.Width + x;
+                    int t2 = y * tileSize.Width + (tileSize.Width - 1 - x);
+
+                    IndexedPixel swap = tile[t1];
+                    tile[t1] = tile[t2];
+                    tile[t2] = swap;
+                }
+            }
+        }
+
+        private void FlipVertical(Span<IndexedPixel> tile)
+        {
+            for (int x = 0; x < tileSize.Width; x++) {
+                for (int y = 0; y < tileSize.Height / 2; y++) {
+                    int t1 = x + tileSize.Width * y;
+                    int t2 = x + tileSize.Width * (tileSize.Height - 1 - y);
+
+                    IndexedPixel swap = tile[t1];
+                    tile[t1] = tile[t2];
+                    tile[t2] = swap;
+                }
+            }
+        }
+    }
+}

--- a/src/Texim/Compressions/Nitro/MapDecompression.cs
+++ b/src/Texim/Compressions/Nitro/MapDecompression.cs
@@ -94,43 +94,15 @@ namespace Texim.Compressions.Nitro
                 }
 
                 if (info.HorizontalFlip) {
-                    FlipHorizontal(tileOut);
+                    tileOut.FlipHorizontal(tileSize);
                 }
 
                 if (info.VerticalFlip) {
-                    FlipVertical(tileOut);
+                    tileOut.FlipVertical(tileSize);
                 }
             }
 
             return decompressed;
-        }
-
-        private void FlipHorizontal(Span<IndexedPixel> tile)
-        {
-            for (int y = 0; y < tileSize.Height; y++) {
-                for (int x = 0; x < tileSize.Width / 2; x++) {
-                    int t1 = (y * tileSize.Width) + x;
-                    int t2 = (y * tileSize.Width) + (tileSize.Width - 1 - x);
-
-                    IndexedPixel swap = tile[t1];
-                    tile[t1] = tile[t2];
-                    tile[t2] = swap;
-                }
-            }
-        }
-
-        private void FlipVertical(Span<IndexedPixel> tile)
-        {
-            for (int x = 0; x < tileSize.Width; x++) {
-                for (int y = 0; y < tileSize.Height / 2; y++) {
-                    int t1 = x + (tileSize.Width * y);
-                    int t2 = x + (tileSize.Width * (tileSize.Height - 1 - y));
-
-                    IndexedPixel swap = tile[t1];
-                    tile[t1] = tile[t2];
-                    tile[t2] = swap;
-                }
-            }
         }
     }
 }

--- a/src/Texim/Compressions/Nitro/MapDecompression.cs
+++ b/src/Texim/Compressions/Nitro/MapDecompression.cs
@@ -109,8 +109,8 @@ namespace Texim.Compressions.Nitro
         {
             for (int y = 0; y < tileSize.Height; y++) {
                 for (int x = 0; x < tileSize.Width / 2; x++) {
-                    int t1 = y * tileSize.Width + x;
-                    int t2 = y * tileSize.Width + (tileSize.Width - 1 - x);
+                    int t1 = (y * tileSize.Width) + x;
+                    int t2 = (y * tileSize.Width) + (tileSize.Width - 1 - x);
 
                     IndexedPixel swap = tile[t1];
                     tile[t1] = tile[t2];
@@ -123,8 +123,8 @@ namespace Texim.Compressions.Nitro
         {
             for (int x = 0; x < tileSize.Width; x++) {
                 for (int y = 0; y < tileSize.Height / 2; y++) {
-                    int t1 = x + tileSize.Width * y;
-                    int t2 = x + tileSize.Width * (tileSize.Height - 1 - y);
+                    int t1 = x + (tileSize.Width * y);
+                    int t2 = x + (tileSize.Width * (tileSize.Height - 1 - y));
 
                     IndexedPixel swap = tile[t1];
                     tile[t1] = tile[t2];

--- a/src/Texim/Compressions/Nitro/MapDecompressionParameters.cs
+++ b/src/Texim/Compressions/Nitro/MapDecompressionParameters.cs
@@ -17,10 +17,10 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
-using System.Drawing;
-
 namespace Texim.Compressions.Nitro
 {
+    using System.Drawing;
+
     public class MapDecompressionParameters
     {
         public IScreenMap Map { get; set; }

--- a/src/Texim/Compressions/Nitro/MapDecompressionParameters.cs
+++ b/src/Texim/Compressions/Nitro/MapDecompressionParameters.cs
@@ -1,0 +1,30 @@
+// Copyright (c) 2021 SceneGate
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+using System.Drawing;
+
+namespace Texim.Compressions.Nitro
+{
+    public class MapDecompressionParameters
+    {
+        public IScreenMap Map { get; set; }
+
+        public Size TileSize { get; set; } = new Size(8, 8);
+    }
+}

--- a/src/Texim/Compressions/Nitro/MapInfo.cs
+++ b/src/Texim/Compressions/Nitro/MapInfo.cs
@@ -1,0 +1,48 @@
+// Copyright (c) 2021 SceneGate
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+namespace Texim.Compressions.Nitro
+{
+    public readonly struct MapInfo
+    {
+        public MapInfo(short value)
+        {
+            TileIndex = (short)(value & 0x3FF);
+            HorizontalFlip = (value >> 10) == 1;
+            VerticalFlip = (value >> 11) == 1;
+            PaletteIndex = (byte)(value >> 12);
+        }
+
+        public short TileIndex { get; init; }
+
+        public bool HorizontalFlip { get; init; }
+
+        public bool VerticalFlip { get; init; }
+
+        public byte PaletteIndex { get; init; }
+
+        public readonly short ToInt16()
+        {
+            return (short)((TileIndex & 0x3FF)
+                | ((HorizontalFlip ? 1 : 0) << 10)
+                | ((VerticalFlip ? 1 : 0) << 11)
+                | ((PaletteIndex & 0x0F) << 12));
+        }
+    }
+}

--- a/src/Texim/Compressions/Nitro/ScreenMap.cs
+++ b/src/Texim/Compressions/Nitro/ScreenMap.cs
@@ -1,0 +1,37 @@
+// Copyright (c) 2021 SceneGate
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+namespace Texim.Compressions.Nitro
+{
+    public class ScreenMap : IScreenMap
+    {
+        public ScreenMap(int width, int height)
+        {
+            Width = width;
+            Height = height;
+            Maps = new MapInfo[width * height];
+        }
+
+        public MapInfo[] Maps { get; init; }
+
+        public int Width { get; init; }
+
+        public int Height { get; init; }
+    }
+}

--- a/src/Texim/Compressions/Nitro/TileExtensions.cs
+++ b/src/Texim/Compressions/Nitro/TileExtensions.cs
@@ -1,0 +1,86 @@
+// Copyright (c) 2021 SceneGate
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+namespace Texim.Compressions.Nitro
+{
+    using System;
+    using System.Drawing;
+    using Texim.Pixels;
+
+    public static class TileExtensions
+    {
+        public static bool HasEquivalentIndexes(this Memory<IndexedPixel> tile1, Memory<IndexedPixel> tile2)
+        {
+            return tile1.Span.HasEquivalentIndexes(tile2.Span);
+        }
+
+        public static bool HasEquivalentIndexes(this Span<IndexedPixel> tile1, Span<IndexedPixel> tile2)
+        {
+            if (tile1.Length != tile2.Length) {
+                return false;
+            }
+
+            for (int i = 0; i < tile1.Length; i++) {
+                if (tile1[i].Index != tile2[i].Index) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        public static void FlipHorizontal(this Memory<IndexedPixel> tile, Size tileSize)
+        {
+            tile.Span.FlipHorizontal(tileSize);
+        }
+
+        public static void FlipHorizontal(this Span<IndexedPixel> tile, Size tileSize)
+        {
+            for (int y = 0; y < tileSize.Height; y++) {
+                for (int x = 0; x < tileSize.Width / 2; x++) {
+                    int t1 = (y * tileSize.Width) + x;
+                    int t2 = (y * tileSize.Width) + (tileSize.Width - 1 - x);
+
+                    IndexedPixel swap = tile[t1];
+                    tile[t1] = tile[t2];
+                    tile[t2] = swap;
+                }
+            }
+        }
+
+        public static void FlipVertical(this Memory<IndexedPixel> tile, Size tileSize)
+        {
+            tile.Span.FlipVertical(tileSize);
+        }
+
+        public static void FlipVertical(this Span<IndexedPixel> tile, Size tileSize)
+        {
+            for (int x = 0; x < tileSize.Width; x++) {
+                for (int y = 0; y < tileSize.Height / 2; y++) {
+                    int t1 = x + (tileSize.Width * y);
+                    int t2 = x + (tileSize.Width * (tileSize.Height - 1 - y));
+
+                    IndexedPixel swap = tile[t1];
+                    tile[t1] = tile[t2];
+                    tile[t2] = swap;
+                }
+            }
+        }
+    }
+}

--- a/src/Texim/Pixels/TileSwizzling.cs
+++ b/src/Texim/Pixels/TileSwizzling.cs
@@ -23,6 +23,7 @@ namespace Texim.Pixels
     using System.Collections.Generic;
     using System.Drawing;
     using System.Linq;
+    using Yarhl.IO;
 
     public class TileSwizzling<T> : ISwizzling<T>
     {
@@ -73,12 +74,12 @@ namespace Texim.Pixels
             // If the image is incomplete there may missing tiles but in order
             // to set some pixels we will need a square image so we can skip
             // the missing pixels.
-            int height = input.Length / Width;
+            int height = (input.Length / Width).Pad(TileSize.Height);
             T[] output = new T[Width * height];
             for (int linealIndex = 0; linealIndex < input.Length; linealIndex++) {
                 int tiledIndex = GetTiledIndex(linealIndex % Width, linealIndex / Width);
                 if (decoding) {
-                    output[linealIndex] = input[tiledIndex];
+                    output[linealIndex] = tiledIndex < input.Length ? input[tiledIndex] : default;
                 } else {
                     output[tiledIndex] = input[linealIndex];
                 }


### PR DESCRIPTION
### Description

The NDS, GBA and other N devices can compress images by storing only the unique tiles. There is a special memory location where the program can specify how to map the tiles into the screen "decompressing" the image.

This PR implements this compression via the interface `IScreenMap` and class `ScreenMap`. The converter `MapDecompression` can decompress an array of pixel or an indexed image. The converter `MapCompression` can compress an indexed image into the new class `IndexedMapImage` that combines the interfaces `IScreenMap` and `IIndexedImage`. This converter assumes the tiles fill the requirement of using just one palette (quantization to be implemented).

Also implements the deserializer for the NDS format `NSCR` for maps.