### PR TITLE
Implement tile quantization with fixed palettes and merge image with map compression

### DIFF
--- a/src/Texim.Tool/Program.cs
+++ b/src/Texim.Tool/Program.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Program.cs
 //
 // Author:
@@ -89,7 +89,7 @@ namespace Texim.Tool
 
             NodeFactory.FromFile(binaryFile, FileOpenMode.Read)
                 .TransformWith<Ykcmp2Image>()
-                .TransformWith<FullImage2BinaryBitmap, ImageFormat>(ImageFormat.Png)
+                .TransformWith<FullImage2Bitmap, ImageFormat>(ImageFormat.Png)
                 .Stream.WriteTo(imageFile);
         }
 
@@ -111,7 +111,7 @@ namespace Texim.Tool
 
             NodeFactory.FromFile(binaryFile)
                 .TransformWith<Ptmd2Image>()
-                .TransformWith<FullImage2BinaryBitmap, ImageFormat>(ImageFormat.Png)
+                .TransformWith<FullImage2Bitmap, ImageFormat>(ImageFormat.Png)
                 .Stream.WriteTo(imageFile);
         }
 
@@ -142,8 +142,8 @@ namespace Texim.Tool
             MmTex texture = oldImage.GetFormatAs<MmTex>();
 
             // To export the image:
-            var exporterParams = new IndexedImageBitmapParameters { Palette = texture };
-            oldImage.TransformWith<IndexedImage2BinaryBitmap, IndexedImageBitmapParameters>(exporterParams)
+            var exporterParams = new IndexedImageBitmapParams { Palette = texture };
+            oldImage.TransformWith<IndexedImage2Bitmap, IndexedImageBitmapParams>(exporterParams)
                 .Stream.WriteTo("img.png");
 
             // Import the new PNG file
@@ -194,10 +194,10 @@ namespace Texim.Tool
                    .ToArray();
 
             // To export the image:
-            var exporterParameters = new IndexedImageBitmapParameters { Palette = palette.GetFormatAs<Palette>() };
+            var exporterParameters = new IndexedImageBitmapParams { Palette = palette.GetFormatAs<Palette>() };
             NodeFactory.FromFile("auction_price.cmp.decompressed")
                 .TransformWith<DsTex2Image>()
-                .TransformWith<IndexedImage2BinaryBitmap, IndexedImageBitmapParameters>(exporterParameters)
+                .TransformWith<IndexedImage2Bitmap, IndexedImageBitmapParams>(exporterParameters)
                 .Stream.WriteTo("img.png");
 
             // Import the new PNG file

--- a/src/Texim/Colors/Rgb.cs
+++ b/src/Texim/Colors/Rgb.cs
@@ -65,7 +65,7 @@ namespace Texim.Colors
 
         public readonly Color ToColor() => Color.FromArgb(Alpha, Red, Green, Blue);
 
-        public readonly double GetDistanceSquared(Rgb other)
+        public readonly int GetDistanceSquared(Rgb other)
         {
             return ((Red - other.Red) * (Red - other.Red))
                 + ((Green - other.Green) * (Green - other.Green))

--- a/src/Texim/Compressions/Nitro/FullImageMapCompression.cs
+++ b/src/Texim/Compressions/Nitro/FullImageMapCompression.cs
@@ -20,42 +20,42 @@
 namespace Texim.Compressions.Nitro
 {
     using System;
-    using System.Drawing;
     using Texim.Images;
-    using Texim.Palettes;
     using Texim.Pixels;
     using Texim.Processing;
     using Yarhl.FileFormat;
+    using Yarhl.FileSystem;
 
     public class FullImageMapCompression :
-        IInitializer<FullImageMapCompressionParameters>, IConverter<IFullImage, IndexedMapImage>
+        IInitializer<FullImageMapCompressionParams>, IConverter<IFullImage, NodeContainerFormat>
     {
-        private Size tileSize;
-        private IPaletteCollection palettes;
+        private FullImageMapCompressionParams parameters;
 
-        public void Initialize(FullImageMapCompressionParameters parameters)
+        public void Initialize(FullImageMapCompressionParams parameters)
         {
             if (parameters == null)
                 throw new ArgumentNullException(nameof(parameters));
 
-            tileSize = parameters.TileSize;
-            palettes = parameters.Palettes;
+            this.parameters = parameters;
         }
 
-        public IndexedMapImage Convert(IFullImage source)
+        public NodeContainerFormat Convert(IFullImage source)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
 
             // TODO: Avoid several swizzling by providing an argument to quantization
             // and compression (in and out, out here too).
-            var quantization = new FixedPaletteTileQuantization(palettes, tileSize, source.Width);
+            var quantization = new FixedPaletteTileQuantization(
+                parameters.Palettes,
+                parameters.TileSize,
+                source.Width);
             (IndexedPixel[] tiles, _) = quantization.Quantize(source.Pixels);
 
             var fullIndexedImage = new IndexedImage(source.Width, source.Height, tiles);
 
             var compression = new MapCompression();
-            compression.Initialize(tileSize);
+            compression.Initialize(parameters);
             return compression.Convert(fullIndexedImage);
         }
     }

--- a/src/Texim/Compressions/Nitro/FullImageMapCompression.cs
+++ b/src/Texim/Compressions/Nitro/FullImageMapCompression.cs
@@ -1,0 +1,62 @@
+// Copyright (c) 2021 SceneGate
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+namespace Texim.Compressions.Nitro
+{
+    using System;
+    using System.Drawing;
+    using Texim.Images;
+    using Texim.Palettes;
+    using Texim.Pixels;
+    using Texim.Processing;
+    using Yarhl.FileFormat;
+
+    public class FullImageMapCompression :
+        IInitializer<FullImageMapCompressionParameters>, IConverter<IFullImage, IndexedMapImage>
+    {
+        private Size tileSize;
+        private IPaletteCollection palettes;
+
+        public void Initialize(FullImageMapCompressionParameters parameters)
+        {
+            if (parameters == null)
+                throw new ArgumentNullException(nameof(parameters));
+
+            tileSize = parameters.TileSize;
+            palettes = parameters.Palettes;
+        }
+
+        public IndexedMapImage Convert(IFullImage source)
+        {
+            if (source == null)
+                throw new ArgumentNullException(nameof(source));
+
+            // TODO: Avoid several swizzling by providing an argument to quantization
+            // and compression (in and out, out here too).
+            var quantization = new FixedPaletteTileQuantization(palettes, tileSize, source.Width);
+            (IndexedPixel[] tiles, _) = quantization.Quantize(source.Pixels);
+
+            var fullIndexedImage = new IndexedImage(source.Width, source.Height, tiles);
+
+            var compression = new MapCompression();
+            compression.Initialize(tileSize);
+            return compression.Convert(fullIndexedImage);
+        }
+    }
+}

--- a/src/Texim/Compressions/Nitro/FullImageMapCompressionParameters.cs
+++ b/src/Texim/Compressions/Nitro/FullImageMapCompressionParameters.cs
@@ -1,0 +1,31 @@
+// Copyright (c) 2021 SceneGate
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+namespace Texim.Compressions.Nitro
+{
+    using System.Drawing;
+    using Texim.Palettes;
+
+    public class FullImageMapCompressionParameters
+    {
+        public IPaletteCollection Palettes { get; set; }
+
+        public Size TileSize { get; set; } = new Size(8, 8);
+    }
+}

--- a/src/Texim/Compressions/Nitro/FullImageMapCompressionParams.cs
+++ b/src/Texim/Compressions/Nitro/FullImageMapCompressionParams.cs
@@ -19,13 +19,10 @@
 // SOFTWARE.
 namespace Texim.Compressions.Nitro
 {
-    using System.Drawing;
     using Texim.Palettes;
 
-    public class FullImageMapCompressionParameters
+    public class FullImageMapCompressionParams : MapCompressionParams
     {
         public IPaletteCollection Palettes { get; set; }
-
-        public Size TileSize { get; set; } = new Size(8, 8);
     }
 }

--- a/src/Texim/Compressions/Nitro/MapCompressionParams.cs
+++ b/src/Texim/Compressions/Nitro/MapCompressionParams.cs
@@ -19,17 +19,13 @@
 // SOFTWARE.
 namespace Texim.Compressions.Nitro
 {
+    using System.Drawing;
     using Texim.Images;
-    using Texim.Pixels;
 
-    public class IndexedMapImage : IScreenMap, IIndexedImage
+    public class MapCompressionParams
     {
-        public int Width { get; init; }
+        public Size TileSize { get; set; } = new Size(8, 8);
 
-        public int Height { get; init; }
-
-        public MapInfo[] Maps { get; init; }
-
-        public IndexedPixel[] Pixels { get; init; }
+        public IIndexedImage MergeImage { get; set; }
     }
 }

--- a/src/Texim/Compressions/Nitro/MapDecompression.cs
+++ b/src/Texim/Compressions/Nitro/MapDecompression.cs
@@ -49,12 +49,15 @@ namespace Texim.Compressions.Nitro
             if (map == null)
                 throw new InvalidOperationException("Missing initialization");
 
-            // It's easier if we swizzle again
-            var swizzling = new TileSwizzling<IndexedPixel>(source.Width);
+            // It's easier if we swizzle again, with the compressed tiles
+            var swizzling = new TileSwizzling<IndexedPixel>(tileSize, source.Width);
             IndexedPixel[] tiles = swizzling.Swizzle(source.Pixels);
 
             IndexedPixel[] decompressed = DecompressTiles(tiles);
-            decompressed = swizzling.Unswizzle(decompressed);
+
+            // Unswizzle but this time with the final image size
+            var unswizzling = new TileSwizzling<IndexedPixel>(tileSize, map.Width);
+            decompressed = unswizzling.Unswizzle(decompressed);
 
             return new IndexedImage(map.Width, map.Height, decompressed);
         }

--- a/src/Texim/Compressions/Nitro/MapDecompression.cs
+++ b/src/Texim/Compressions/Nitro/MapDecompression.cs
@@ -26,14 +26,14 @@ namespace Texim.Compressions.Nitro
     using Yarhl.FileFormat;
 
     public class MapDecompression :
-        IInitializer<MapDecompressionParameters>,
+        IInitializer<MapDecompressionParams>,
         IConverter<IIndexedImage, IndexedImage>,
         IConverter<IndexedPixel[], IndexedPixel[]>
     {
         private Size tileSize;
         private IScreenMap map;
 
-        public void Initialize(MapDecompressionParameters parameters)
+        public void Initialize(MapDecompressionParams parameters)
         {
             if (parameters == null)
                 throw new ArgumentNullException(nameof(parameters));

--- a/src/Texim/Compressions/Nitro/MapDecompressionParams.cs
+++ b/src/Texim/Compressions/Nitro/MapDecompressionParams.cs
@@ -21,7 +21,7 @@ namespace Texim.Compressions.Nitro
 {
     using System.Drawing;
 
-    public class MapDecompressionParameters
+    public class MapDecompressionParams
     {
         public IScreenMap Map { get; set; }
 

--- a/src/Texim/Compressions/Nitro/MapInfo.cs
+++ b/src/Texim/Compressions/Nitro/MapInfo.cs
@@ -29,12 +29,17 @@ namespace Texim.Compressions.Nitro
             PaletteIndex = 0;
         }
 
-        public MapInfo(short value)
+        public MapInfo(ushort value)
         {
             TileIndex = (short)(value & 0x3FF);
-            HorizontalFlip = (value >> 10) == 1;
-            VerticalFlip = (value >> 11) == 1;
+            HorizontalFlip = ((value >> 10) & 0x01) == 1;
+            VerticalFlip = ((value >> 11) & 0x01) == 1;
             PaletteIndex = (byte)(value >> 12);
+        }
+
+        public MapInfo(short value)
+            : this((ushort)value)
+        {
         }
 
         public short TileIndex { get; init; }

--- a/src/Texim/Formats/FullImage2Bitmap.cs
+++ b/src/Texim/Formats/FullImage2Bitmap.cs
@@ -22,44 +22,32 @@ namespace Texim.Formats
     using System;
     using System.Drawing;
     using System.Drawing.Imaging;
-    using Texim.Palettes;
+    using Texim.Images;
     using Yarhl.FileFormat;
     using Yarhl.IO;
 
-    public class Palette2BinaryBitmap :
-       IInitializer<ImageFormat>, IConverter<IPalette, BinaryFormat>
+    public class FullImage2Bitmap :
+        IInitializer<ImageFormat>, IConverter<IFullImage, BinaryFormat>
     {
-        private const int ColorsPerRow = 16;
-        private const int ZoomSize = 10;
         private ImageFormat format = ImageFormat.Png;
 
         public void Initialize(ImageFormat parameters)
         {
+            if (parameters == null)
+                throw new ArgumentNullException(nameof(parameters));
+
             format = parameters;
         }
 
-        public BinaryFormat Convert(IPalette source)
+        public BinaryFormat Convert(IFullImage source)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
 
-            var colors = source.Colors;
-
-            int width = ColorsPerRow * ZoomSize;
-            int height = (int)Math.Ceiling((float)colors.Count / ColorsPerRow);
-            height *= ZoomSize;
-            using var image = new Bitmap(width, height);
-
-            for (int i = 0; i < colors.Count; i++) {
-                Color color = colors[i].ToColor();
-                int colorX = (i % ColorsPerRow) * ZoomSize;
-                int colorY = (i / ColorsPerRow) * ZoomSize;
-
-                // Repeat the same color to create a big square
-                for (int zoomX = 0; zoomX < ZoomSize; zoomX++) {
-                    for (int zoomY = 0; zoomY < ZoomSize; zoomY++) {
-                        image.SetPixel(colorX + zoomX, colorY + zoomY, color);
-                    }
+            using var image = new Bitmap(source.Width, source.Height);
+            for (int x = 0; x < source.Width; x++) {
+                for (int y = 0; y < source.Height; y++) {
+                    image.SetPixel(x, y, source.Pixels[(y * source.Width) + x].ToColor());
                 }
             }
 

--- a/src/Texim/Formats/IndexedImage2BinaryBitmap.cs
+++ b/src/Texim/Formats/IndexedImage2BinaryBitmap.cs
@@ -59,12 +59,18 @@ namespace Texim.Formats
                 for (int y = 0; y < source.Height; y++) {
                     var pixel = source.Pixels[(y * source.Width) + x];
                     if (pixel.PaletteIndex >= palettes.Length) {
-                        throw new FormatException("Missing palettes");
+                        throw new FormatException(
+                            $"[x={x},y={y}] Missing palettes. " +
+                            $"Need palette #{pixel.PaletteIndex} but it has {palettes.Length}. " +
+                            $"First palette length: {palettes[0].Length}");
                     }
 
                     var palette = palettes[pixel.PaletteIndex];
                     if (pixel.Index >= palette.Length) {
-                        throw new FormatException("Missing colors in palette");
+                        throw new FormatException(
+                            $"[x={x},y={y}] Missing colors in palette. " +
+                            $"Need color #{pixel.Index} but palette " +
+                            $"#{pixel.PaletteIndex} has {palette.Length}");
                     }
 
                     Color color = (pixel.Alpha != 255)

--- a/src/Texim/Formats/IndexedImage2Bitmap.cs
+++ b/src/Texim/Formats/IndexedImage2Bitmap.cs
@@ -27,13 +27,13 @@ namespace Texim.Formats
     using Yarhl.FileFormat;
     using Yarhl.IO;
 
-    public class IndexedImage2BinaryBitmap :
-        IInitializer<IndexedImageBitmapParameters>,
+    public class IndexedImage2Bitmap :
+        IInitializer<IndexedImageBitmapParams>,
         IConverter<IIndexedImage, BinaryFormat>
     {
-        private IndexedImageBitmapParameters parameters;
+        private IndexedImageBitmapParams parameters;
 
-        public void Initialize(IndexedImageBitmapParameters parameters)
+        public void Initialize(IndexedImageBitmapParams parameters)
         {
             if (parameters == null)
                 throw new ArgumentNullException(nameof(parameters));

--- a/src/Texim/Formats/IndexedImageBitmapParams.cs
+++ b/src/Texim/Formats/IndexedImageBitmapParams.cs
@@ -22,7 +22,7 @@ namespace Texim.Formats
     using System.Drawing.Imaging;
     using Texim.Palettes;
 
-    public class IndexedImageBitmapParameters
+    public class IndexedImageBitmapParams
     {
         public ImageFormat Format { get; set; } = ImageFormat.Png;
 

--- a/src/Texim/Formats/Palette2Bitmap.cs
+++ b/src/Texim/Formats/Palette2Bitmap.cs
@@ -22,32 +22,44 @@ namespace Texim.Formats
     using System;
     using System.Drawing;
     using System.Drawing.Imaging;
-    using Texim.Images;
+    using Texim.Palettes;
     using Yarhl.FileFormat;
     using Yarhl.IO;
 
-    public class FullImage2BinaryBitmap :
-        IInitializer<ImageFormat>, IConverter<IFullImage, BinaryFormat>
+    public class Palette2Bitmap :
+       IInitializer<ImageFormat>, IConverter<IPalette, BinaryFormat>
     {
+        private const int ColorsPerRow = 16;
+        private const int ZoomSize = 10;
         private ImageFormat format = ImageFormat.Png;
 
         public void Initialize(ImageFormat parameters)
         {
-            if (parameters == null)
-                throw new ArgumentNullException(nameof(parameters));
-
             format = parameters;
         }
 
-        public BinaryFormat Convert(IFullImage source)
+        public BinaryFormat Convert(IPalette source)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
 
-            using var image = new Bitmap(source.Width, source.Height);
-            for (int x = 0; x < source.Width; x++) {
-                for (int y = 0; y < source.Height; y++) {
-                    image.SetPixel(x, y, source.Pixels[(y * source.Width) + x].ToColor());
+            var colors = source.Colors;
+
+            int width = ColorsPerRow * ZoomSize;
+            int height = (int)Math.Ceiling((float)colors.Count / ColorsPerRow);
+            height *= ZoomSize;
+            using var image = new Bitmap(width, height);
+
+            for (int i = 0; i < colors.Count; i++) {
+                Color color = colors[i].ToColor();
+                int colorX = (i % ColorsPerRow) * ZoomSize;
+                int colorY = (i / ColorsPerRow) * ZoomSize;
+
+                // Repeat the same color to create a big square
+                for (int zoomX = 0; zoomX < ZoomSize; zoomX++) {
+                    for (int zoomY = 0; zoomY < ZoomSize; zoomY++) {
+                        image.SetPixel(colorX + zoomX, colorY + zoomY, color);
+                    }
                 }
             }
 

--- a/src/Texim/Formats/PaletteCollection2ContainerBitmap.cs
+++ b/src/Texim/Formats/PaletteCollection2ContainerBitmap.cs
@@ -43,7 +43,7 @@ namespace Texim.Formats
             var container = new NodeContainerFormat();
             for (int i = 0; i < source.Palettes.Count; i++) {
                 var child = new Node($"Palette {i}", source.Palettes[i])
-                    .TransformWith<Palette2BinaryBitmap>();
+                    .TransformWith<Palette2Bitmap>();
                 container.Root.Add(child);
             }
 

--- a/src/Texim/Formats/RawBinary2Palette.cs
+++ b/src/Texim/Formats/RawBinary2Palette.cs
@@ -25,11 +25,11 @@ namespace Texim.Formats
     using Yarhl.IO;
 
     public class RawBinary2Palette :
-        IInitializer<RawPaletteParameters>, IConverter<BinaryFormat, Palette>
+        IInitializer<RawPaletteParams>, IConverter<BinaryFormat, Palette>
     {
-        private RawPaletteParameters parameters = RawPaletteParameters.Default;
+        private RawPaletteParams parameters = RawPaletteParams.Default;
 
-        public void Initialize(RawPaletteParameters parameters)
+        public void Initialize(RawPaletteParams parameters)
         {
             if (parameters == null)
                 throw new ArgumentNullException(nameof(parameters));

--- a/src/Texim/Formats/RawPaletteParams.cs
+++ b/src/Texim/Formats/RawPaletteParams.cs
@@ -21,9 +21,9 @@ namespace Texim.Formats
 {
     using Texim.Colors;
 
-    public class RawPaletteParameters
+    public class RawPaletteParams
     {
-        public static RawPaletteParameters Default => new RawPaletteParameters {
+        public static RawPaletteParams Default => new RawPaletteParams {
             Offset = 0,
             Size = -1,
             ColorEncoding = Bgr555.Instance,

--- a/src/Texim/Pixels/BytePixelEncoding.cs
+++ b/src/Texim/Pixels/BytePixelEncoding.cs
@@ -50,7 +50,7 @@ namespace Texim.Pixels
             int numPixels = data.Length * (8 / BitsPerPixel);
             var pixels = new IndexedPixel[numPixels];
 
-            int mask = (0xFF << (8 - BitsPerPixel)) >> (8 - BitsPerPixel);
+            int mask = (1 << BitsPerPixel) - 1;
             for (int i = 0, bitPos = 0; i < numPixels; i++, bitPos += BitsPerPixel) {
                 byte value = (byte)((data[bitPos / 8] >> (bitPos % 8)) & mask);
                 pixels[i] = BitsToPixel(value);

--- a/src/Texim/Pixels/TileSwizzling.cs
+++ b/src/Texim/Pixels/TileSwizzling.cs
@@ -42,6 +42,7 @@ namespace Texim.Pixels
         public TileSwizzling(Size tileSize, int width)
         {
             TileSize = tileSize;
+            Width = width;
         }
 
         public Size TileSize { get; set; }

--- a/src/Texim/Processing/ExhaustiveColorSearch.cs
+++ b/src/Texim/Processing/ExhaustiveColorSearch.cs
@@ -32,25 +32,32 @@ namespace Texim.Processing
             this.vertex = vertex.ToArray();
         }
 
-        public int Search(Rgb color)
+        public static (int Index, int Distance) Search(IEnumerable<Rgb> vertex, Rgb color)
         {
+            var vertexArray = (vertex as Rgb[]) ?? vertex.ToArray();
+
             // Set the largest distance and a null index
-            double minDistance = (255 * 255) + (255 * 255) + (255 * 255) + 1;
+            int minDistance = (255 * 255) + (255 * 255) + (255 * 255) + 1;
             int nearestColor = -1;
 
             // FUTURE: Implement "Approximate Nearest Neighbors in Non-Euclidean Spaces"
             // algorithm or k-d tree if it's computing CIE76 color difference
-            for (int i = 0; i < vertex.Length && minDistance > 0; i++) {
+            for (int i = 0; i < vertexArray.Length && minDistance > 0; i++) {
                 // Since we only want the value to compare,
                 // it is faster to not computer the squared root
-                double distance = color.GetDistanceSquared(this.vertex[i]);
+                int distance = color.GetDistanceSquared(vertexArray[i]);
                 if (distance < minDistance) {
                     minDistance = distance;
                     nearestColor = i;
                 }
             }
 
-            return nearestColor;
+            return (nearestColor, minDistance);
+        }
+
+        public (int Index, int Distance) Search(Rgb color)
+        {
+            return Search(vertex, color);
         }
     }
 }

--- a/src/Texim/Processing/FixedPaletteQuantization.cs
+++ b/src/Texim/Processing/FixedPaletteQuantization.cs
@@ -43,7 +43,7 @@ namespace Texim.Processing
             for (int i = 0; i < pixels.Length; i++) {
                 int colorIdx = (FirstAsTransparent && pixels[i].Alpha >= 128)
                     ? 0
-                    : search.Search(pixels[i]);
+                    : search.Search(pixels[i]).Index;
                 indexed[i] = new IndexedPixel((short)colorIdx, pixels[i].Alpha, 0);
             }
 

--- a/src/Texim/Processing/FixedPaletteTileQuantization.cs
+++ b/src/Texim/Processing/FixedPaletteTileQuantization.cs
@@ -1,0 +1,108 @@
+// Copyright (c) 2021 SceneGate
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+namespace Texim.Processing
+{
+    using System;
+    using System.Drawing;
+    using System.Linq;
+    using Texim.Colors;
+    using Texim.Palettes;
+    using Texim.Pixels;
+
+    public class FixedPaletteTileQuantization : IQuantization
+    {
+        private readonly IPaletteCollection paletteCollection;
+        private readonly Rgb[][] palettes;
+        private readonly Size tileSize;
+        private readonly int width;
+
+        public FixedPaletteTileQuantization(IPaletteCollection palettes, Size tileSize, int width)
+        {
+            if (palettes == null)
+                throw new ArgumentNullException(nameof(palettes));
+
+            this.paletteCollection = palettes;
+            this.palettes = palettes.Palettes.Select(p => p.Colors.ToArray()).ToArray();
+            this.width = width;
+            this.tileSize = tileSize;
+        }
+
+        public bool FirstAsTransparent { get; set; }
+
+        public (IndexedPixel[], IPaletteCollection) Quantize(Rgb[] pixels)
+        {
+            // Swizzle to work with tiles
+            var colorSwizzling = new TileSwizzling<Rgb>(tileSize, width);
+            Rgb[] tiles = colorSwizzling.Swizzle(pixels);
+
+            IndexedPixel[] indexed = new IndexedPixel[pixels.Length];
+            Span<IndexedPixel> output = indexed;
+            ReadOnlySpan<Rgb> input = pixels;
+
+            int tileLength = tileSize.Width * tileSize.Height;
+            for (int i = 0; i < pixels.Length; i += tileLength) {
+                var tileIn = input.Slice(i, tileLength);
+                var tileOut = output.Slice(i, tileLength);
+                int paletteIdx = SearchNearestPalette(tileIn);
+                ApproximateTile(tileIn, paletteIdx, tileOut);
+            }
+
+            // Unswizzle to return
+            var indexSwizzling = new TileSwizzling<IndexedPixel>(tileSize, width);
+            return (indexSwizzling.Unswizzle(indexed), paletteCollection);
+        }
+
+        private void ApproximateTile(ReadOnlySpan<Rgb> tile, int paletteIdx, Span<IndexedPixel> output)
+        {
+            for (int i = 0; i < tile.Length; i++) {
+                int colorIdx = (FirstAsTransparent && tile[i].Alpha >= 128)
+                    ? 0
+                    : ExhaustiveColorSearch.Search(palettes[paletteIdx], tile[i]).Index;
+                output[i] = new IndexedPixel((short)colorIdx, tile[i].Alpha, (byte)paletteIdx);
+            }
+        }
+
+        private int SearchNearestPalette(ReadOnlySpan<Rgb> tile)
+        {
+            int minDistance = int.MaxValue;
+            int nearestPalette = -1;
+
+            for (int i = 0; i < palettes.Length; i++) {
+                int distance = GetTilePaletteDistance(tile, palettes[i]);
+                if (distance < minDistance) {
+                    minDistance = distance;
+                    nearestPalette = i;
+                }
+            }
+
+            return nearestPalette;
+        }
+
+        private int GetTilePaletteDistance(ReadOnlySpan<Rgb> tile, Rgb[] palette)
+        {
+            int totalDistance = 0;
+            for (int i = 0; i < tile.Length; i++) {
+                totalDistance += ExhaustiveColorSearch.Search(palette, tile[i]).Distance;
+            }
+
+            return totalDistance;
+        }
+    }
+}

--- a/src/Texim/Processing/FixedPaletteTileQuantization.cs
+++ b/src/Texim/Processing/FixedPaletteTileQuantization.cs
@@ -54,7 +54,7 @@ namespace Texim.Processing
 
             IndexedPixel[] indexed = new IndexedPixel[pixels.Length];
             Span<IndexedPixel> output = indexed;
-            ReadOnlySpan<Rgb> input = pixels;
+            ReadOnlySpan<Rgb> input = tiles;
 
             int tileLength = tileSize.Width * tileSize.Height;
             for (int i = 0; i < pixels.Length; i += tileLength) {


### PR DESCRIPTION
### Description

Implement a color quantization for tiled-base images that can use a different palette per tile. This quantization use a set of fixed palettes, it doesn't generate them.

Also, implement merging images while compressing with screen maps for N consoles (case one NCGR, multiple NSCR). Doing a map compression outputs a node with two formats: the indexed image and the screen map. Before we were merging into one type but the width & height fields were overlapping and causing issues when processing the tile compressing part as the width is not valid now.

Other fixes:

- Fix issue parsing MapInfo
- Fix issue decoding 4bpp pixels.
- Fix issue doing map decompression
- Fix issue initializing TileSwizzling
- Rename some classes to keep shorter and easy to use names.