### PR TITLE
:sparkles: :bug: Implement export sprites API and fix reading little endian pixels and quantization problems

### DIFF
--- a/src/Texim.Tool/Megaman/BinarySpr2Sprite.cs
+++ b/src/Texim.Tool/Megaman/BinarySpr2Sprite.cs
@@ -1,0 +1,197 @@
+// Copyright (c) 2022 SceneGate
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+namespace Texim.Tool.Megaman;
+
+using System;
+using Texim.Colors;
+using Texim.Images;
+using Texim.Palettes;
+using Texim.Pixels;
+using Texim.Sprites;
+using Yarhl.FileFormat;
+using Yarhl.FileSystem;
+using Yarhl.IO;
+
+public class BinarySpr2Sprite : IConverter<IBinary, NodeContainerFormat>
+{
+    private DataReader reader;
+    private uint dataOffset;
+    private uint paletteOffset;
+    private uint animationOffset;
+    private uint spritesOffset;
+
+    public NodeContainerFormat Convert(IBinary source)
+    {
+        if (source is null)
+            throw new ArgumentNullException(nameof(source));
+
+        var container = new NodeContainerFormat();
+        reader = new DataReader(source.Stream);
+
+        ReadHeader();
+
+        var pixels = ReadPixels();
+        container.Root.Add(new Node("pixels", pixels));
+
+        var palettes = ReadPalettes();
+        container.Root.Add(new Node("palettes", palettes));
+
+        source.Stream.Position = animationOffset;
+        int numAnimations = reader.ReadInt32();
+        for (int i = 0; i < numAnimations; i++) {
+            var node = ReadAnimationSprites(i);
+            container.Root.Add(node);
+        }
+
+        return container;
+    }
+
+    private void ReadHeader()
+    {
+        dataOffset = reader.ReadUInt32();
+        paletteOffset = reader.ReadUInt32();
+        animationOffset = reader.ReadUInt32();
+        spritesOffset = reader.ReadUInt32();
+        reader.ReadUInt32(); // unknown, is tiled?
+    }
+
+    private IndexedImage ReadPixels()
+    {
+        reader.Stream.Position = dataOffset;
+        int sceneWidth = reader.ReadInt16();
+        reader.ReadInt16(); // sceneHeight
+        uint pixelsOffset = reader.ReadUInt32(); // then there is an unknown uint per element
+
+        reader.Stream.Position = dataOffset + pixelsOffset;
+        int pixelsLength = (int)(paletteOffset - reader.Stream.Position);
+        var pixels = reader.ReadPixels<Indexed4Bpp>(pixelsLength)
+            .UnswizzleWith(new TileSwizzling<IndexedPixel>(sceneWidth));
+
+        // sceneWidth happens to be also the num of tiles, so we can use it as width and 64 as height
+        return new IndexedImage {
+            Pixels = pixels,
+            Width = sceneWidth,
+            Height = 64,
+        };
+    }
+
+    private PaletteCollection ReadPalettes()
+    {
+        reader.Stream.Position = paletteOffset;
+
+        reader.ReadInt16(); // color format?
+        short numPalettes = reader.ReadInt16();
+
+        var palettes = new PaletteCollection();
+        for (int i = 0; i < numPalettes; i++) {
+            var palette = new Palette(reader.ReadColors<Bgr555>(16));
+            palettes.Palettes.Add(palette);
+        }
+
+        return palettes;
+    }
+
+    private Node ReadAnimationSprites(int index)
+    {
+        reader.Stream.Position = animationOffset;
+        int numAnimations = reader.ReadInt32();
+
+        reader.Stream.Position += index * 4;
+        uint offset = reader.ReadUInt32();
+        uint nextOffset = (index == numAnimations - 1)
+            ? (spritesOffset - animationOffset)
+            : reader.ReadUInt32();
+        int numSprites = (int)(nextOffset - offset) / 4;
+
+        var spritesNode = new Node($"ani_{index}");
+        reader.Stream.Position = animationOffset + offset;
+        for (int i = 0; i < numSprites; i++) {
+            int spriteIndex = reader.ReadByte();
+            reader.ReadByte(); // unknown, animation related?
+            reader.ReadByte(); // unknown, animation related?
+            int paletteIndex = reader.ReadByte();
+
+            reader.Stream.PushCurrentPosition();
+            var sprite = ReadSprite(spriteIndex, paletteIndex);
+            spritesNode.Add(new Node($"frame_{i}", sprite));
+            reader.Stream.PopPosition();
+        }
+
+        return spritesNode;
+    }
+
+    private Sprite ReadSprite(int index, int paletteIndex)
+    {
+        reader.Stream.Position = spritesOffset;
+        int numSprites = reader.ReadInt32();
+
+        reader.Stream.Position += index * 4;
+        uint offset = reader.ReadUInt32();
+        uint nextOffset = (index == numSprites - 1)
+            ? (uint)(reader.Stream.Length - spritesOffset)
+            : reader.ReadUInt32();
+        int numElements = (int)(nextOffset - offset) / 8;
+
+        var sprite = new Sprite();
+        reader.Stream.Position = spritesOffset + offset;
+        for (int i = 0; i < numElements; i++) {
+            short tileIndex = reader.ReadByte();
+            int coordX = reader.ReadSByte();
+            int coordY = reader.ReadSByte();
+            int sizeMode = reader.ReadByte();
+            int shape = reader.ReadByte();
+            reader.ReadByte(); // unknown
+            int layer = reader.ReadByte();
+            reader.ReadByte(); // unknown
+
+            var (width, height) = GetSize(shape, sizeMode);
+
+            sprite.Segments.Add(new ImageSegment {
+                TileIndex = tileIndex,
+                CoordinateX = coordX,
+                CoordinateY = coordY,
+                Width = width,
+                Height = height,
+                Layer = layer,
+                PaletteIndex = (byte)paletteIndex,
+                HorizontalFlip = false,
+                VerticalFlip = false,
+            });
+        }
+
+        return sprite;
+    }
+
+    private (int width, int height) GetSize(int shape, int mode)
+    {
+        int[,] sizeMatrix = new int[3, 4] {
+            { 8, 16, 32, 64 }, // Square
+            { 16, 32, 32, 64 }, // Horizontal
+            { 8, 8, 16, 32 }, // Vertical
+        };
+
+        return shape switch {
+            0 => (sizeMatrix[0, mode], sizeMatrix[0, mode]),
+            1 => (sizeMatrix[1, mode], sizeMatrix[2, mode]),
+            2 => (sizeMatrix[2, mode], sizeMatrix[1, mode]),
+            _ => throw new FormatException("Unknown size mode")
+        };
+    }
+}

--- a/src/Texim.Tool/Megaman/BinarySpr2Sprite.cs
+++ b/src/Texim.Tool/Megaman/BinarySpr2Sprite.cs
@@ -80,13 +80,13 @@ public class BinarySpr2Sprite : IConverter<IBinary, NodeContainerFormat>
         reader.Stream.Position = dataOffset + pixelsOffset;
         int pixelsLength = (int)(paletteOffset - reader.Stream.Position);
         var pixels = reader.ReadPixels<Indexed4Bpp>(pixelsLength * 2)
-            .UnswizzleWith(new TileSwizzling<IndexedPixel>(sceneWidth));
+            .UnswizzleWith(new TileSwizzling<IndexedPixel>(64));
 
-        // sceneWidth happens to be also the num of tiles, so we can use it as width and 64 as height
+        // sceneWidth happens to be also the num of tiles, so we can use it as height and 64 as width
         return new IndexedImage {
             Pixels = pixels,
-            Width = sceneWidth,
-            Height = 64,
+            Width = 64,
+            Height = sceneHeight,
         };
     }
 

--- a/src/Texim.Tool/Megaman/CommandLine.cs
+++ b/src/Texim.Tool/Megaman/CommandLine.cs
@@ -1,0 +1,74 @@
+// Copyright (c) 2022 SceneGate
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+namespace Texim.Tool.Megaman;
+
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using System.IO;
+using Texim.Formats;
+using Texim.Images;
+using Texim.Palettes;
+using Texim.Sprites;
+using Yarhl.FileSystem;
+using Yarhl.IO;
+
+public static class CommandLine
+{
+    public static Command CreateCommand()
+    {
+        var exportSprite = new Command("export_sprite", "Export sprites") {
+                new Option<string>("--input", "the .spr sprite file", ArgumentArity.ExactlyOne),
+                new Option<string>("--output", "the output directory", ArgumentArity.ExactlyOne),
+                new Option<StandardPaletteFormat>("--format", "the output format", ArgumentArity.ExactlyOne),
+            };
+        exportSprite.Handler = CommandHandler.Create<string, string, StandardPaletteFormat>(ExportSprite);
+
+        return new Command("megaman", "Megaman NDS game") {
+            exportSprite,
+        };
+    }
+
+    public static void ExportSprite(string input, string output, StandardPaletteFormat format)
+    {
+        var node = NodeFactory.FromFile(input, FileOpenMode.Read)
+            .TransformWith<BinarySpr2Sprite>();
+
+        var image = node.Children["pixels"].GetFormatAs<IndexedImage>();
+        var palettes = node.Children["palettes"].GetFormatAs<PaletteCollection>();
+
+        var spriteParams = new ImageSegment2IndexedImageParams {
+            FullImage = image,
+            TileSize = new System.Drawing.Size(8, 8),
+        };
+        var bitmapParams = new IndexedImageBitmapParams {
+            Palettes = palettes,
+        };
+
+        foreach (var animation in node.Children["animations"].Children) {
+            string name = animation.Name;
+            foreach (var frame in animation.Children) {
+                string outputFile = Path.Combine(output, name, $"{frame.Name}.png");
+                frame.TransformWith<Sprite2IndexedImage, ImageSegment2IndexedImageParams>(spriteParams)
+                    .TransformWith<IndexedImage2Bitmap, IndexedImageBitmapParams>(bitmapParams)
+                    .Stream.WriteTo(outputFile);
+            }
+        }
+    }
+}

--- a/src/Texim/Pixels/BytePixelEncoding.cs
+++ b/src/Texim/Pixels/BytePixelEncoding.cs
@@ -53,11 +53,13 @@ namespace Texim.Pixels
             int numPixels = data.Length * (8 / BitsPerPixel);
             var pixels = new IndexedPixel[numPixels];
 
-            int endiannessShift = (Endianness == EndiannessMode.LittleEndian) ? 0 : BitsPerPixel;
             int mask = (1 << BitsPerPixel) - 1;
             for (int i = 0, bitPos = 0; i < numPixels; i++, bitPos += BitsPerPixel) {
-                byte value = (byte)((data[bitPos / 8] >> (endiannessShift - (bitPos % 8))) & mask);
-                pixels[i] = BitsToPixel(value);
+                int endiannessShift = (Endianness == EndiannessMode.LittleEndian)
+                    ? (bitPos % 8)
+                    : (BitsPerPixel - (bitPos % 8));
+                int value = (data[bitPos / 8] >> endiannessShift) & mask;
+                pixels[i] = BitsToPixel((byte)value);
             }
 
             return pixels;
@@ -68,7 +70,6 @@ namespace Texim.Pixels
             if (pixels == null)
                 throw new ArgumentNullException(nameof(pixels));
 
-            int endiannessShift = (Endianness == EndiannessMode.LittleEndian) ? 0 : BitsPerPixel;
             var pixelList = pixels.ToArray();
             int numBytes = pixelList.Length * BitsPerPixel / 8;
             byte[] data = new byte[numBytes];
@@ -76,8 +77,12 @@ namespace Texim.Pixels
             for (int i = 0, bitPos = 0; i < pixelList.Length; i++, bitPos += BitsPerPixel) {
                 byte pixelData = PixelToBits(pixelList[i]);
 
+                int endiannessShift = (Endianness == EndiannessMode.LittleEndian)
+                    ? (bitPos % 8)
+                    : (BitsPerPixel - (bitPos % 8));
+
                 byte value = data[bitPos / 8];
-                value |= (byte)(pixelData << (endiannessShift - (bitPos % 8)));
+                value |= (byte)(pixelData << endiannessShift);
                 data[bitPos / 8] = value;
             }
 

--- a/src/Texim/Pixels/TileExtensions.cs
+++ b/src/Texim/Pixels/TileExtensions.cs
@@ -17,10 +17,9 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
-namespace Texim.Compressions.Nitro
+namespace Texim.Pixels
 {
     using System;
-    using Texim.Pixels;
 
     public static class TileExtensions
     {

--- a/src/Texim/Processing/FixedPaletteTileQuantization.cs
+++ b/src/Texim/Processing/FixedPaletteTileQuantization.cs
@@ -71,7 +71,7 @@ namespace Texim.Processing
         private void ApproximateTile(ReadOnlySpan<Rgb> tile, int paletteIdx, Span<IndexedPixel> output)
         {
             for (int i = 0; i < tile.Length; i++) {
-                int colorIdx = (FirstAsTransparent && tile[i].Alpha >= 128)
+                int colorIdx = (FirstAsTransparent && tile[i].Alpha <= 128)
                     ? 0
                     : ExhaustiveColorSearch.Search(palettes[paletteIdx], tile[i]).Index;
                 output[i] = new IndexedPixel((short)colorIdx, tile[i].Alpha, (byte)paletteIdx);

--- a/src/Texim/Processing/Quantization.cs
+++ b/src/Texim/Processing/Quantization.cs
@@ -39,7 +39,7 @@ namespace Texim.Processing
             }
 
             for (int i = 0; i < pixels.Length; i++) {
-                if (FirstAsTransparent && pixels[i].Alpha >= 128) {
+                if (FirstAsTransparent && pixels[i].Alpha <= 128) {
                     indexed[i] = new IndexedPixel(0, pixels[i].Alpha, 0);
                     continue;
                 }

--- a/src/Texim/Sprites/IImageSegment.cs
+++ b/src/Texim/Sprites/IImageSegment.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 SceneGate
+// Copyright (c) 2022 SceneGate
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -17,27 +17,25 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
-namespace Texim.Tool
+namespace Texim.Sprites;
+
+public interface IImageSegment
 {
-    using System.CommandLine;
-    using System.Threading.Tasks;
+    int Layer { get; }
 
-    public static class Program
-    {
-        public static Task<int> Main(string[] args)
-        {
-            var root = new RootCommand("Proof-of-concept library and tool for image formats");
-            root.Add(Nitro.CommandLine.CreateCommand());
-            root.Add(BlackRockShooter.CommandLine.CreateCommand());
-            root.Add(DevilSurvivor.CommandLine.CreateCommand());
-            root.Add(Disgaea.CommandLine.CreateCommand());
-            root.Add(MetalMax.CommandLine.CreateCommand());
-            root.Add(LondonLife.CommandLine.CreateCommand());
-            root.Add(Megaman.CommandLine.CreateCommand());
-            root.Add(Raw.CommandLine.CreateCommand());
-            root.Add(Darko.CommandLine.CreateCommand());
+    int CoordinateX { get; }
 
-            return root.InvokeAsync(args);
-        }
-    }
+    int CoordinateY { get; }
+
+    int Width { get; }
+
+    int Height { get; }
+
+    short TileIndex { get; }
+
+    bool HorizontalFlip { get; }
+
+    bool VerticalFlip { get; }
+
+    byte PaletteIndex { get; }
 }

--- a/src/Texim/Sprites/ISprite.cs
+++ b/src/Texim/Sprites/ISprite.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 SceneGate
+// Copyright (c) 2022 SceneGate
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -17,27 +17,16 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
-namespace Texim.Tool
+namespace Texim.Sprites;
+
+using System.Collections.ObjectModel;
+using Yarhl.FileFormat;
+
+public interface ISprite : IFormat
 {
-    using System.CommandLine;
-    using System.Threading.Tasks;
+    Collection<IImageSegment> Segments { get; }
 
-    public static class Program
-    {
-        public static Task<int> Main(string[] args)
-        {
-            var root = new RootCommand("Proof-of-concept library and tool for image formats");
-            root.Add(Nitro.CommandLine.CreateCommand());
-            root.Add(BlackRockShooter.CommandLine.CreateCommand());
-            root.Add(DevilSurvivor.CommandLine.CreateCommand());
-            root.Add(Disgaea.CommandLine.CreateCommand());
-            root.Add(MetalMax.CommandLine.CreateCommand());
-            root.Add(LondonLife.CommandLine.CreateCommand());
-            root.Add(Megaman.CommandLine.CreateCommand());
-            root.Add(Raw.CommandLine.CreateCommand());
-            root.Add(Darko.CommandLine.CreateCommand());
+    int Width { get; }
 
-            return root.InvokeAsync(args);
-        }
-    }
+    int Height { get; }
 }

--- a/src/Texim/Sprites/ImageSegment.cs
+++ b/src/Texim/Sprites/ImageSegment.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 SceneGate
+// Copyright (c) 2022 SceneGate
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -17,27 +17,25 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
-namespace Texim.Tool
+namespace Texim.Sprites;
+
+public class ImageSegment : IImageSegment
 {
-    using System.CommandLine;
-    using System.Threading.Tasks;
+    public int Layer { get; set; }
 
-    public static class Program
-    {
-        public static Task<int> Main(string[] args)
-        {
-            var root = new RootCommand("Proof-of-concept library and tool for image formats");
-            root.Add(Nitro.CommandLine.CreateCommand());
-            root.Add(BlackRockShooter.CommandLine.CreateCommand());
-            root.Add(DevilSurvivor.CommandLine.CreateCommand());
-            root.Add(Disgaea.CommandLine.CreateCommand());
-            root.Add(MetalMax.CommandLine.CreateCommand());
-            root.Add(LondonLife.CommandLine.CreateCommand());
-            root.Add(Megaman.CommandLine.CreateCommand());
-            root.Add(Raw.CommandLine.CreateCommand());
-            root.Add(Darko.CommandLine.CreateCommand());
+    public int CoordinateX { get; set; }
 
-            return root.InvokeAsync(args);
-        }
-    }
+    public int CoordinateY { get; set; }
+
+    public int Width { get; init; }
+
+    public int Height { get; init; }
+
+    public short TileIndex { get; init; }
+
+    public bool HorizontalFlip { get; init; }
+
+    public bool VerticalFlip { get; init; }
+
+    public byte PaletteIndex { get; set; }
 }

--- a/src/Texim/Sprites/ImageSegment2IndexedImage.cs
+++ b/src/Texim/Sprites/ImageSegment2IndexedImage.cs
@@ -1,0 +1,100 @@
+// Copyright (c) 2022 SceneGate
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+namespace Texim.Sprites;
+
+using System;
+using Texim.Images;
+using Texim.Pixels;
+using Yarhl.FileFormat;
+
+public class ImageSegment2IndexedImage :
+    IInitializer<ImageSegment2IndexedImageParams>,
+    IConverter<IImageSegment, IndexedImage>
+{
+    private ImageSegment2IndexedImageParams parameters;
+
+    public void Initialize(ImageSegment2IndexedImageParams parameters)
+    {
+        this.parameters = parameters;
+    }
+
+    public IndexedImage Convert(IImageSegment source)
+    {
+        if (source is null)
+            throw new ArgumentNullException(nameof(source));
+        if (parameters is null)
+            throw new InvalidOperationException("Missing initialization");
+
+        // It's easier if we swizzle again, with the compressed tiles
+        var swizzling = new TileSwizzling<IndexedPixel>(parameters.TileSize, parameters.FullImage.Width);
+        IndexedPixel[] tiles = swizzling.Swizzle(parameters.FullImage.Pixels);
+
+        var segmentTiles = GetSegmentTiles(tiles, source);
+
+        // Unswizzle but this time with the final image size
+        var unswizzling = new TileSwizzling<IndexedPixel>(parameters.TileSize, source.Width);
+        var segmentPixels = unswizzling.Unswizzle(segmentTiles);
+
+        // We flip treating the full image unswizzle as a tile
+        Span<IndexedPixel> spanSegment = segmentPixels;
+        if (source.HorizontalFlip) {
+            spanSegment.FlipHorizontal(new System.Drawing.Size(source.Width, source.Height));
+        }
+
+        if (source.VerticalFlip) {
+            spanSegment.FlipVertical(new System.Drawing.Size(source.Width, source.Height));
+        }
+
+        return new IndexedImage {
+            Height = source.Height,
+            Width = source.Width,
+            Pixels = segmentPixels,
+        };
+    }
+
+    private IndexedPixel[] GetSegmentTiles(IndexedPixel[] source, IImageSegment segment)
+    {
+        var segmentPixels = new IndexedPixel[segment.Width * segment.Height];
+        Span<IndexedPixel> pixelsOut = segmentPixels;
+        Span<IndexedPixel> pixelsIn = source;
+
+        int pixelsPerTile = parameters.TileSize.Width * parameters.TileSize.Height;
+        int numPixels = segment.Width * segment.Height;
+
+        int startIndex = segment.TileIndex * pixelsPerTile;
+        if (startIndex + numPixels > pixelsIn.Length || startIndex < 0) {
+            if (parameters.OutOfBoundsTileIndex == -1) {
+                throw new FormatException($"Required tile index {segment.TileIndex} is out of bounds");
+            } else {
+                startIndex = parameters.OutOfBoundsTileIndex * pixelsPerTile;
+            }
+        }
+
+        Span<IndexedPixel> tilesIn = pixelsIn.Slice(startIndex, numPixels);
+        for (int t = 0; t < numPixels; t++) {
+            pixelsOut[t] = new IndexedPixel(
+                tilesIn[t].Index,
+                tilesIn[t].Alpha,
+                segment.PaletteIndex);
+        }
+
+        return segmentPixels;
+    }
+}

--- a/src/Texim/Sprites/ImageSegment2IndexedImageParams.cs
+++ b/src/Texim/Sprites/ImageSegment2IndexedImageParams.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 SceneGate
+// Copyright (c) 2022 SceneGate
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -17,27 +17,15 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
-namespace Texim.Tool
+namespace Texim.Sprites;
+
+using Texim.Images;
+
+public class ImageSegment2IndexedImageParams
 {
-    using System.CommandLine;
-    using System.Threading.Tasks;
+    public System.Drawing.Size TileSize { get; set; }
 
-    public static class Program
-    {
-        public static Task<int> Main(string[] args)
-        {
-            var root = new RootCommand("Proof-of-concept library and tool for image formats");
-            root.Add(Nitro.CommandLine.CreateCommand());
-            root.Add(BlackRockShooter.CommandLine.CreateCommand());
-            root.Add(DevilSurvivor.CommandLine.CreateCommand());
-            root.Add(Disgaea.CommandLine.CreateCommand());
-            root.Add(MetalMax.CommandLine.CreateCommand());
-            root.Add(LondonLife.CommandLine.CreateCommand());
-            root.Add(Megaman.CommandLine.CreateCommand());
-            root.Add(Raw.CommandLine.CreateCommand());
-            root.Add(Darko.CommandLine.CreateCommand());
+    public IndexedImage FullImage { get; set; }
 
-            return root.InvokeAsync(args);
-        }
-    }
+    public int OutOfBoundsTileIndex { get; set; } = -1;
 }

--- a/src/Texim/Sprites/Sprite.cs
+++ b/src/Texim/Sprites/Sprite.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 SceneGate
+// Copyright (c) 2022 SceneGate
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -17,27 +17,15 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
-namespace Texim.Tool
+namespace Texim.Sprites;
+
+using System.Collections.ObjectModel;
+
+public class Sprite : ISprite
 {
-    using System.CommandLine;
-    using System.Threading.Tasks;
+    public Collection<IImageSegment> Segments { get; init; } = new Collection<IImageSegment>();
 
-    public static class Program
-    {
-        public static Task<int> Main(string[] args)
-        {
-            var root = new RootCommand("Proof-of-concept library and tool for image formats");
-            root.Add(Nitro.CommandLine.CreateCommand());
-            root.Add(BlackRockShooter.CommandLine.CreateCommand());
-            root.Add(DevilSurvivor.CommandLine.CreateCommand());
-            root.Add(Disgaea.CommandLine.CreateCommand());
-            root.Add(MetalMax.CommandLine.CreateCommand());
-            root.Add(LondonLife.CommandLine.CreateCommand());
-            root.Add(Megaman.CommandLine.CreateCommand());
-            root.Add(Raw.CommandLine.CreateCommand());
-            root.Add(Darko.CommandLine.CreateCommand());
+    public int Width { get; set; }
 
-            return root.InvokeAsync(args);
-        }
-    }
+    public int Height { get; set; }
 }

--- a/src/Texim/Sprites/Sprite2IndexedImage.cs
+++ b/src/Texim/Sprites/Sprite2IndexedImage.cs
@@ -1,0 +1,83 @@
+// Copyright (c) 2022 SceneGate
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+namespace Texim.Sprites;
+
+using System;
+using System.Linq;
+using Texim.Images;
+using Texim.Pixels;
+using Yarhl.FileFormat;
+
+public class Sprite2IndexedImage :
+    IInitializer<ImageSegment2IndexedImageParams>,
+    IConverter<ISprite, IndexedImage>
+{
+    private readonly ImageSegment2IndexedImage segmentConverter = new ();
+    private ImageSegment2IndexedImageParams parameters;
+
+    public void Initialize(ImageSegment2IndexedImageParams parameters)
+    {
+        this.parameters = parameters;
+        segmentConverter.Initialize(parameters);
+    }
+
+    public IndexedImage Convert(ISprite source)
+    {
+        if (source is null)
+            throw new ArgumentNullException(nameof(source));
+        if (parameters is null)
+            throw new InvalidOperationException("Missing initialization");
+
+        var pixels = new IndexedPixel[source.Width * source.Height];
+        Span<IndexedPixel> pixelsSpan = pixels;
+
+        int centerX = source.Width / 2;
+        int centerY = source.Height / 2;
+        foreach (var segment in source.Segments.OrderBy(s => s.Layer)) {
+            CopySegment(segment, pixelsSpan, source.Width, centerX, centerY);
+        }
+
+        var image = new IndexedImage {
+            Pixels = pixels,
+            Width = source.Width,
+            Height = source.Height,
+        };
+
+        return image;
+    }
+
+    private void CopySegment(IImageSegment segment, Span<IndexedPixel> output, int width, int centerX, int centerY)
+    {
+        IndexedImage segmentImage = segmentConverter.Convert(segment);
+
+        for (int x = 0; x < segment.Width; x++) {
+            for (int y = 0; y < segment.Height; y++) {
+                int inIdx = (y * segment.Width) + x;
+                IndexedPixel pixel = segmentImage.Pixels[inIdx];
+                if (pixel.Alpha == 0 || pixel.Index == 0) {
+                    continue;
+                }
+
+                int outIdx = ((centerY + segment.CoordinateY + y) * width) + (centerX + segment.CoordinateX + x);
+                output[outIdx] = pixel;
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Description

Implement API to export sprite images, that is, images created by small pieces of images (objects / OAMs).
These pieces are represented by `IImageSegment` (`ImageSegment` default class). A segment just point to the position of the tiles in the image, has a size, a position in the image and layer index. A `ISprite` (`Sprite`) is the collection of these segments that are drawn in a canvas of a given size.

There are two new converters `ImageSegment2IndexedImage` to convert each of these segments into images and `Sprite2IndexedImage` to convert the sprites with all its segments into an image.

Also fix a bug introduced in the previous PR for reading little endian pixels. And more bugs in the color quantization treating pixels are transparency.

### Example

As an examples, we can export the sprites from megaman.
