### PR TITLE
:sparkles: Implement NCER deserialization

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -5,7 +5,7 @@ root = true
 [*.cs]
 
 ## Generic options
-charset = utf-8-bom
+charset = utf-8
 indent_size = 4
 indent_style = space
 tab_width = 8
@@ -122,39 +122,39 @@ csharp_new_line_before_members_in_anonymous_types = true
 csharp_new_line_between_query_expression_clauses = true
 
 ### Indentation preferences
-csharp_indent_case_contents = true:warning
-csharp_indent_switch_labels = true:warning
-csharp_indent_labels = one_less_than_current:warning
-csharp_indent_block_contents = true:warning
-csharp_indent_braces = false:warning
-csharp_indent_case_contents_when_block = false:warning
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = one_less_than_current
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents_when_block = false
 
 ### Spacing preferences
-csharp_space_after_cast = false:warning
-csharp_space_after_keywords_in_control_flow_statements = true:warning
-csharp_space_between_parentheses = false:warning
-csharp_space_before_colon_in_inheritance_clause = true:warning
-csharp_space_after_colon_in_inheritance_clause = true:warning
-csharp_space_around_binary_operators = before_and_after:warning
-csharp_space_between_method_declaration_parameter_list_parentheses = false:warning
-csharp_space_between_method_declaration_empty_parameter_list_parentheses = false:warning
-csharp_space_between_method_declaration_name_and_open_parenthesis = false:warning
-csharp_space_between_method_call_parameter_list_parentheses = false:warning
-csharp_space_between_method_call_empty_parameter_list_parentheses = false:warning
-csharp_space_between_method_call_name_and_opening_parenthesis = false:warning
-csharp_space_after_comma = true:warning
-csharp_space_before_comma = false:warning
-csharp_space_after_dot = false:warning
-csharp_space_before_dot = false:warning
-csharp_space_after_semicolon_in_for_statement = true:warning
-csharp_space_before_semicolon_in_for_statement = false:warning
-csharp_space_around_declaration_statements = false:warning
-csharp_space_before_open_square_brackets = false:warning
-csharp_space_between_empty_square_brackets = false:warning
-csharp_space_between_square_brackets = false:warning
+csharp_space_after_cast = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_between_parentheses = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_after_comma = true
+csharp_space_before_comma = false
+csharp_space_after_dot = false
+csharp_space_before_dot = false
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_around_declaration_statements = false
+csharp_space_before_open_square_brackets = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_square_brackets = false
 
 ### Wrapping preferences
-csharp_preserve_single_line_statements = false:warning
+csharp_preserve_single_line_statements = false
 csharp_preserve_single_line_blocks = true
 
 ## Naming styles rules

--- a/src/Texim.Tool/JumpUltimateStars/BinaryDstx2SpriteImage.cs
+++ b/src/Texim.Tool/JumpUltimateStars/BinaryDstx2SpriteImage.cs
@@ -83,7 +83,7 @@ public class BinaryDstx2SpriteImage : IConverter<IBinary, NodeContainerFormat>
             var segment = new ImageSegment {
                 Width = width * 8,
                 Height = height * 8,
-                TileIndex = (tileIndex == 0) ? (short)1 : tileIndex,
+                TileIndex = (tileIndex == 0) ? 1 : tileIndex,
                 CoordinateX = 0,
                 CoordinateY = y,
             };

--- a/src/Texim.Tool/JumpUltimateStars/BinaryKShape2SpriteCollection.cs
+++ b/src/Texim.Tool/JumpUltimateStars/BinaryKShape2SpriteCollection.cs
@@ -82,7 +82,7 @@ public class BinaryKShape2SpriteCollection : IConverter<IBinary, KShapeSprites>
                 var segment = new ImageSegment {
                     Width = SegmentDimensions,
                     Height = SegmentDimensions,
-                    TileIndex = (short)tileIdx,
+                    TileIndex = tileIdx,
                     CoordinateX = x,
                     CoordinateY = y,
                 };

--- a/src/Texim.Tool/Megaman/BinarySpr2Sprite.cs
+++ b/src/Texim.Tool/Megaman/BinarySpr2Sprite.cs
@@ -138,7 +138,7 @@ public class BinarySpr2Sprite : IConverter<IBinary, NodeContainerFormat>
             int spriteIndex = reader.ReadByte();
             reader.ReadByte(); // unknown, animation related?
             reader.ReadByte(); // unknown, animation related?
-            int paletteIndex = reader.ReadByte();
+            byte paletteIndex = reader.ReadByte();
 
             reader.Stream.PushCurrentPosition();
             var sprite = ReadSprite(spriteIndex, paletteIndex);
@@ -149,7 +149,7 @@ public class BinarySpr2Sprite : IConverter<IBinary, NodeContainerFormat>
         return spritesNode;
     }
 
-    private Sprite ReadSprite(int index, int paletteIndex)
+    private Sprite ReadSprite(int index, byte paletteIndex)
     {
         reader.Stream.Position = spritesOffset;
         int numSprites = reader.ReadInt32();
@@ -180,13 +180,13 @@ public class BinarySpr2Sprite : IConverter<IBinary, NodeContainerFormat>
             var (width, height) = GetSize(shape, sizeMode);
 
             sprite.Segments.Add(new ImageSegment {
-                TileIndex = (short)tileIndex,
+                TileIndex = tileIndex,
                 CoordinateX = coordX,
                 CoordinateY = coordY,
                 Width = width,
                 Height = height,
                 Layer = layer,
-                PaletteIndex = (byte)paletteIndex,
+                PaletteIndex = paletteIndex,
                 HorizontalFlip = false,
                 VerticalFlip = false,
             });

--- a/src/Texim.Tool/Nitro/Binary2Ncer.cs
+++ b/src/Texim.Tool/Nitro/Binary2Ncer.cs
@@ -1,0 +1,117 @@
+﻿// Copyright (c) 2022 SceneGate
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+namespace Texim.Tool.Nitro;
+
+using System;
+using Yarhl.FileSystem;
+using Yarhl.IO;
+
+/// <summary>
+/// Converter that deserializes a NCER binary stream into a container of sprites.
+/// </summary>
+public class Binary2Ncer : NitroDeserializer<Ncer>
+{
+    protected override string Stamp => "NCER";
+
+    protected override void ReadSection(DataReader reader, Ncer model, string id, int size)
+    {
+        switch (id) {
+            case "CEBK":
+                ReadCellBank(reader, model);
+                break;
+
+            case "LABL":
+            case "UEXT":
+                // TODO
+                break;
+
+            default:
+                throw new FormatException($"Unknown section: {id}");
+        }
+    }
+
+    private void ReadCellBank(DataReader reader, Ncer model)
+    {
+        long sectionPos = reader.Stream.Position;
+
+        // Read header
+        ushort numCells = reader.ReadUInt16();
+        model.Attributes = (CellBankAttributes)reader.ReadUInt16();
+        uint cellsDataOffset = reader.ReadUInt32();
+        model.TileMapping = (CellTileMappingKind)reader.ReadInt32();
+        uint vramDataOffset = reader.ReadUInt32();
+        _ = reader.ReadUInt32(); // unused pointer
+        uint extendedDataOffset = reader.ReadUInt32();
+
+        int cellInfoSize = model.Attributes.HasFlag(CellBankAttributes.CellsWithBoundary) ? 0x10 : 0x08;
+        long segmentsPosition = sectionPos + cellsDataOffset + (numCells * cellInfoSize);
+
+        for (int i = 0; i < numCells; i++) {
+            reader.Stream.Position = sectionPos + cellsDataOffset + (i * cellInfoSize);
+            Cell cell = ReadCell(reader, model, segmentsPosition);
+            model.Root.Add(new Node($"cell{i}", cell));
+        }
+
+        // TODO: Read
+        reader.Stream.Position = sectionPos + vramDataOffset;
+
+        // TODO: Read
+        reader.Stream.Position = sectionPos + extendedDataOffset;
+    }
+
+    private Cell ReadCell(DataReader reader, Ncer model, long segmentsPosition)
+    {
+        var cell = new Cell();
+
+        ushort numSegments = reader.ReadUInt16();
+        cell.Attributes = CellAttributes.FromBinary(reader.ReadUInt16());
+        uint segmentsOffset = reader.ReadUInt32();
+
+        if (cell.Attributes.IsSquare) {
+            cell.Width = cell.Attributes.SquareDimension;
+            cell.Height = cell.Attributes.SquareDimension;
+        } else if (model.Attributes.HasFlag(CellBankAttributes.CellsWithBoundary)) {
+            short maxX = reader.ReadInt16();
+            short maxY = reader.ReadInt16();
+            short minX = reader.ReadInt16();
+            short minY = reader.ReadInt16();
+            cell.Width = maxX - minX;
+            cell.Height = maxY - minY;
+            cell.BoundaryX = minX;
+            cell.BoundaryY = minY;
+        } else {
+            cell.Width = 512;
+            cell.Height = 256;
+        }
+
+        cell.Width = 512;
+        cell.Height = 256;
+
+        int tileBlockSize = model.TileMapping.GetTileBlockSize();
+        reader.Stream.Position = segmentsPosition + segmentsOffset;
+        for (int i = 0; i < numSegments; i++) {
+            ObjectAttributeMemory oam = reader.ReadOam();
+            oam.TileIndex *= tileBlockSize;
+            cell.Segments.Add(oam);
+        }
+
+        return cell;
+    }
+}

--- a/src/Texim.Tool/Nitro/Cell.cs
+++ b/src/Texim.Tool/Nitro/Cell.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 SceneGate
+﻿// Copyright (c) 2022 SceneGate
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -17,25 +17,25 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
-namespace Texim.Sprites;
+namespace Texim.Tool.Nitro;
 
-public class ImageSegment : IImageSegment
+using System.Collections.ObjectModel;
+using Sprites;
+
+/// <summary>
+/// Nitro sprite definition.
+/// </summary>
+public class Cell : ISprite
 {
-    public int Layer { get; set; }
+    public Collection<IImageSegment> Segments { get; init; } = new Collection<IImageSegment>();
 
-    public int CoordinateX { get; set; }
+    public int Width { get; set; }
 
-    public int CoordinateY { get; set; }
+    public int Height { get; set; }
 
-    public int Width { get; init; }
+    public CellAttributes Attributes { get; set; }
 
-    public int Height { get; init; }
+    public int BoundaryX { get; set; }
 
-    public int TileIndex { get; init; }
-
-    public bool HorizontalFlip { get; init; }
-
-    public bool VerticalFlip { get; init; }
-
-    public byte PaletteIndex { get; set; }
+    public int BoundaryY { get; set; }
 }

--- a/src/Texim.Tool/Nitro/Cell.cs
+++ b/src/Texim.Tool/Nitro/Cell.cs
@@ -38,4 +38,6 @@ public class Cell : ISprite
     public int BoundaryX { get; set; }
 
     public int BoundaryY { get; set; }
+
+    public uint UserExtendedCellAttribute { get; set; }
 }

--- a/src/Texim.Tool/Nitro/CellAttributes.cs
+++ b/src/Texim.Tool/Nitro/CellAttributes.cs
@@ -17,25 +17,26 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
-namespace Texim.Sprites;
+namespace Texim.Tool.Nitro;
 
-public class ImageSegment : IImageSegment
+using System;
+
+public class CellAttributes
 {
-    public int Layer { get; set; }
+    public bool UseFlipFlags => throw new NotSupportedException("Unknown flag");
 
-    public int CoordinateX { get; set; }
+    public int RenderingOptimizationFlags => throw new NotSupportedException("Unknown flags");
 
-    public int CoordinateY { get; set; }
+    public int UnknownFlags { get; set; }
 
-    public int Width { get; init; }
+    public bool IsSquare { get; set; }
 
-    public int Height { get; init; }
+    public int SquareDimension { get; set; }
 
-    public int TileIndex { get; init; }
-
-    public bool HorizontalFlip { get; init; }
-
-    public bool VerticalFlip { get; init; }
-
-    public byte PaletteIndex { get; set; }
+    public static CellAttributes FromBinary(ushort data) =>
+        new CellAttributes {
+            IsSquare = ((data >> 11) & 1) == 0,
+            SquareDimension = (data & 0x3F) * 8,
+            UnknownFlags = data >> 6,
+        };
 }

--- a/src/Texim.Tool/Nitro/CellBankAttributes.cs
+++ b/src/Texim.Tool/Nitro/CellBankAttributes.cs
@@ -17,25 +17,12 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
-namespace Texim.Sprites;
+namespace Texim.Tool.Nitro;
 
-public class ImageSegment : IImageSegment
+using System;
+
+[Flags]
+public enum CellBankAttributes
 {
-    public int Layer { get; set; }
-
-    public int CoordinateX { get; set; }
-
-    public int CoordinateY { get; set; }
-
-    public int Width { get; init; }
-
-    public int Height { get; init; }
-
-    public int TileIndex { get; init; }
-
-    public bool HorizontalFlip { get; init; }
-
-    public bool VerticalFlip { get; init; }
-
-    public byte PaletteIndex { get; set; }
+    CellsWithBoundary = 1 << 0,
 }

--- a/src/Texim.Tool/Nitro/CellTileMappingKind.cs
+++ b/src/Texim.Tool/Nitro/CellTileMappingKind.cs
@@ -17,25 +17,19 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
-namespace Texim.Sprites;
+namespace Texim.Tool.Nitro;
 
-public class ImageSegment : IImageSegment
+public enum CellTileMappingKind
 {
-    public int Layer { get; set; }
+    Tile1D_32k,
+    Tile1D_64k,
+    Tile1D_128k,
+    Tile1D_256k,
+    Tile2D,
+    Max,
+}
 
-    public int CoordinateX { get; set; }
-
-    public int CoordinateY { get; set; }
-
-    public int Width { get; init; }
-
-    public int Height { get; init; }
-
-    public int TileIndex { get; init; }
-
-    public bool HorizontalFlip { get; init; }
-
-    public bool VerticalFlip { get; init; }
-
-    public byte PaletteIndex { get; set; }
+public static class CellTileMappingKindExtensions
+{
+    public static int GetTileBlockSize(this CellTileMappingKind kind) => (1 << (5 + (int)kind)) / 64;
 }

--- a/src/Texim.Tool/Nitro/CommandLine.cs
+++ b/src/Texim.Tool/Nitro/CommandLine.cs
@@ -180,6 +180,7 @@ namespace Texim.Tool.Nitro
                 IsTiled = pixels.IsTiled,
             };
 
+            Console.WriteLine($"Exporting {sprites.Children.Count} sprites");
             foreach (Node sprite in sprites.Children) {
                 if (sprite.GetFormatAs<Cell>() !.Segments.Count == 0) {
                     continue;

--- a/src/Texim.Tool/Nitro/CommandLine.cs
+++ b/src/Texim.Tool/Nitro/CommandLine.cs
@@ -29,6 +29,7 @@ namespace Texim.Tool.Nitro
     using Texim.Images;
     using Texim.Palettes;
     using Texim.Processing;
+    using Texim.Sprites;
     using Yarhl.FileFormat;
     using Yarhl.FileSystem;
     using Yarhl.IO;
@@ -52,6 +53,16 @@ namespace Texim.Tool.Nitro
                 new Option<StandardImageFormat>("format", "Output image format", ArgumentArity.ZeroOrOne),
             };
             exportImage.Handler = CommandHandler.Create<string, string, string, string, StandardImageFormat>(ExportImage);
+
+            var exportSprite = new Command("export_sprite", "Export Nitro files into an sprite image") {
+                new Option<string>("--nclr", "nitro palette file", ArgumentArity.ExactlyOne),
+                new Option<string>("--ncgr", "nitro pixel file", ArgumentArity.ExactlyOne),
+                new Option<string>("--ncer", "nitro cell file", ArgumentArity.ZeroOrOne),
+                new Option<string>("--output", "Output folder", ArgumentArity.ExactlyOne),
+                new Option<StandardImageFormat>("format", "Output image format", ArgumentArity.ZeroOrOne),
+            };
+            exportSprite.Handler =
+                CommandHandler.Create<string, string, string, string, StandardImageFormat>(ExportSprite);
 
             var importImage = new Command("import_image", "Import an image as Nitro image") {
                 new Option<string>("--input", "the input image file", ArgumentArity.ExactlyOne),
@@ -77,6 +88,7 @@ namespace Texim.Tool.Nitro
             return new Command("nitro", "Nintendo DS standard formats") {
                 exportPalette,
                 exportImage,
+                exportSprite,
                 importImage,
                 importCompressedImage,
             };
@@ -138,6 +150,46 @@ namespace Texim.Tool.Nitro
             };
             pixels.TransformWith<IndexedImage2Bitmap, IndexedImageBitmapParams>(indexedParams)
                 .Stream.WriteTo(output);
+        }
+
+        private static void ExportSprite(
+            string nclr,
+            string ncgr,
+            string ncer,
+            string output,
+            StandardImageFormat format)
+        {
+            var palette = NodeFactory.FromFile(nclr, FileOpenMode.Read)
+                .TransformWith<Binary2Nclr>()
+                .GetFormatAs<Nclr>();
+
+            var pixels = NodeFactory.FromFile(ncgr, FileOpenMode.Read)
+                .TransformWith<Binary2Ncgr>()
+                .GetFormatAs<Ncgr>() !;
+
+            var indexedParams = new IndexedImageBitmapParams {
+                Palettes = palette,
+                Encoder = format.GetEncoder(),
+            };
+
+            var sprites = NodeFactory.FromFile(ncer, FileOpenMode.Read)
+                .TransformWith<Binary2Ncer>();
+            var spriteParams = new Sprite2IndexedImageParams {
+                FullImage = pixels,
+                RelativeCoordinates = SpriteRelativeCoordinatesKind.Center,
+                IsTiled = pixels.IsTiled,
+            };
+
+            foreach (Node sprite in sprites.Children) {
+                if (sprite.GetFormatAs<Cell>() !.Segments.Count == 0) {
+                    continue;
+                }
+
+                string outputImage = Path.Combine(output, sprite.Name + ".png");
+                sprite.TransformWith<Sprite2IndexedImage, Sprite2IndexedImageParams>(spriteParams)
+                    .TransformWith<IndexedImage2Bitmap, IndexedImageBitmapParams>(indexedParams)
+                    .Stream!.WriteTo(outputImage);
+            }
         }
 
         private static void ImportImage(string input, string nclr, string output, string ncgr, int paletteIndex = 0)

--- a/src/Texim.Tool/Nitro/INitroFormat.cs
+++ b/src/Texim.Tool/Nitro/INitroFormat.cs
@@ -25,5 +25,7 @@ namespace Texim.Tool.Nitro
     public interface INitroFormat : IFormat
     {
         Version Version { get; set; }
+
+        byte[] UserExtendedInfo { get; set; }
     }
 }

--- a/src/Texim.Tool/Nitro/Ncer.cs
+++ b/src/Texim.Tool/Nitro/Ncer.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 SceneGate
+﻿// Copyright (c) 2022 SceneGate
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -17,25 +17,24 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
-namespace Texim.Sprites;
+namespace Texim.Tool.Nitro;
 
-public class ImageSegment : IImageSegment
+using System;
+using Yarhl.FileSystem;
+
+/// <summary>
+/// Nitro CEll Resource. Format that contains sprite definitions.
+/// </summary>
+public class Ncer : NodeContainerFormat, INitroFormat
 {
-    public int Layer { get; set; }
+    public Ncer()
+    {
+        Version = new Version(1, 0);
+    }
 
-    public int CoordinateX { get; set; }
+    public Version Version { get; set; }
 
-    public int CoordinateY { get; set; }
+    public CellBankAttributes Attributes { get; set; }
 
-    public int Width { get; init; }
-
-    public int Height { get; init; }
-
-    public int TileIndex { get; init; }
-
-    public bool HorizontalFlip { get; init; }
-
-    public bool VerticalFlip { get; init; }
-
-    public byte PaletteIndex { get; set; }
+    public CellTileMappingKind TileMapping { get; set; }
 }

--- a/src/Texim.Tool/Nitro/Ncer.cs
+++ b/src/Texim.Tool/Nitro/Ncer.cs
@@ -20,6 +20,7 @@
 namespace Texim.Tool.Nitro;
 
 using System;
+using System.Collections.ObjectModel;
 using Yarhl.FileSystem;
 
 /// <summary>
@@ -37,4 +38,8 @@ public class Ncer : NodeContainerFormat, INitroFormat
     public CellBankAttributes Attributes { get; set; }
 
     public CellTileMappingKind TileMapping { get; set; }
+
+    public byte[] UserExtendedInfo { get; set; }
+
+    public Collection<string> Labels { get; init; } = new Collection<string>();
 }

--- a/src/Texim.Tool/Nitro/Ncgr.cs
+++ b/src/Texim.Tool/Nitro/Ncgr.cs
@@ -94,5 +94,7 @@ namespace Texim.Tool.Nitro
         public int SourceX { get; set; }
 
         public int SourceY { get; set; }
+
+        public byte[] UserExtendedInfo { get; set; }
     }
 }

--- a/src/Texim.Tool/Nitro/Nclr.cs
+++ b/src/Texim.Tool/Nitro/Nclr.cs
@@ -86,5 +86,7 @@ namespace Texim.Tool.Nitro
         public bool IsExtendedPalette { get; set; }
 
         public NitroTextureFormat TextureFormat { get; set; }
+
+        public byte[] UserExtendedInfo { get; set; }
     }
 }

--- a/src/Texim.Tool/Nitro/Nscr.cs
+++ b/src/Texim.Tool/Nitro/Nscr.cs
@@ -74,5 +74,7 @@ namespace Texim.Tool.Nitro
         public NitroPaletteMode PaletteMode { get; set; }
 
         public NitroBackgroundMode BackgroundMode { get; set; }
+
+        public byte[] UserExtendedInfo { get; set; }
     }
 }

--- a/src/Texim.Tool/Nitro/ObjectAttributeMemory.cs
+++ b/src/Texim.Tool/Nitro/ObjectAttributeMemory.cs
@@ -1,0 +1,94 @@
+// Copyright (c) 2022 SceneGate
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+namespace Texim.Tool.Nitro;
+
+using Sprites;
+
+/// <summary>
+/// Nitro sprite image segment format: Object attribute memory (OAM).
+/// </summary>
+public class ObjectAttributeMemory : IImageSegment
+{
+    public int Layer { get; set; }
+
+    public int CoordinateX { get; set; }
+
+    public int CoordinateY { get; set; }
+
+    public int Width { get; set; }
+
+    public int Height { get; set; }
+
+    public int TileIndex { get; set; }
+
+    public bool HorizontalFlip { get; set; }
+
+    public bool VerticalFlip { get; set; }
+
+    public byte PaletteIndex { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether supports rotation or scaling.
+    /// </summary>
+    public bool HasRotationOrScaling { get; set; }
+
+    /// <summary>
+    /// Gets or sets the rotation or scaling group number.
+    /// There are up to 32 different groups.
+    /// </summary>
+    /// <description>
+    /// The rotation / scaling groups are located after the OAM value in the RAM.
+    /// <see href="http://nocash.emubase.de/gbatek.htm#lcdobjoamrotationscalingparameters"/>
+    /// The transformations are the same as for BG images:
+    /// <see href="http://nocash.emubase.de/gbatek.htm#lcdiobgrotationscaling"/>
+    /// In general, given a group of 4 parameter: A, B, C and D the transformation point is:
+    ///   x2 = A*(x1-x0) + B*(y1-y0) + x0
+    ///   y2 = C*(x1-x0) + D*(y1-y0) + y0
+    /// where (x0, y0) is the rotation center, (x1, y1) is the old point and (x2, y2) the new point.
+    /// </description>
+    public byte RotationOrScalingGroup { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether supports double size.
+    /// </summary>
+    /// <description>
+    /// The sprites are displayed inside a rectangular area. When the sprite is rotated or scaled this area
+    /// could be smaller than needed and some parts could be not displayed.
+    /// Enabling this feature, the rectangular area will be multiplied by 2.
+    /// </description>
+    /// <remarks>Only if Rotation/Scaling is enabled.</remarks>
+    public bool HasDoubleSize { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether is disabled.
+    /// </summary>
+    /// <remarks>Only if Rotation/Scaling is disabled.</remarks>
+    public bool IsDisabled { get; set; }
+
+    public ObjectAttributeMemoryMode Mode { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether mosaic mode is enabled.
+    /// </summary>
+    /// <see href="http://nocash.emubase.de/gbatek.htm#lcdiomosaicfunction"/>
+    public bool IsMosaic { get; set; }
+
+    public NitroPaletteMode PaletteMode { get; set; }
+}

--- a/src/Texim.Tool/Nitro/ObjectAttributeMemoryMode.cs
+++ b/src/Texim.Tool/Nitro/ObjectAttributeMemoryMode.cs
@@ -17,25 +17,12 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
-namespace Texim.Sprites;
+namespace Texim.Tool.Nitro;
 
-public class ImageSegment : IImageSegment
+public enum ObjectAttributeMemoryMode
 {
-    public int Layer { get; set; }
-
-    public int CoordinateX { get; set; }
-
-    public int CoordinateY { get; set; }
-
-    public int Width { get; init; }
-
-    public int Height { get; init; }
-
-    public int TileIndex { get; init; }
-
-    public bool HorizontalFlip { get; init; }
-
-    public bool VerticalFlip { get; init; }
-
-    public byte PaletteIndex { get; set; }
+    Normal = 0,
+    SemiTransparent = 1,
+    ObjWindow = 2,
+    Bitmap = 3,
 }

--- a/src/Texim.Tool/Nitro/ObjectAttributeMemorySerializer.cs
+++ b/src/Texim.Tool/Nitro/ObjectAttributeMemorySerializer.cs
@@ -1,0 +1,106 @@
+// Copyright (c) 2022 SceneGate
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+namespace Texim.Tool.Nitro;
+
+using Yarhl.IO;
+
+public static class ObjectAttributeMemorySerializer
+{
+    private static readonly int[,] SizeMatrix = new int[,] {
+        { 8, 16, 32, 64 }, // Square
+        { 16, 32, 32, 64 }, // Horizontal
+        { 8, 8, 16, 32 }, // Vertical
+    };
+
+    public static ObjectAttributeMemory FromBinary(ushort attr0, ushort attr1, ushort attr2)
+    {
+        var oam = new ObjectAttributeMemory();
+
+        // Attribute 0
+        oam.CoordinateY = (sbyte)(attr0 & 0x0FF);
+        oam.HasRotationOrScaling = ((attr0 >> 8) & 0x01) == 1;
+        if (oam.HasRotationOrScaling) {
+            oam.HasDoubleSize = ((attr0 >> 9) & 0x01) == 1;
+        } else {
+            oam.IsDisabled = ((attr0 >> 9) & 0x01) == 1;
+        }
+
+        oam.Mode = (ObjectAttributeMemoryMode)((attr0 >> 10) & 0x03);
+        oam.IsMosaic = ((attr0 >> 12) & 0x01) == 1;
+        oam.PaletteMode = (NitroPaletteMode)((attr0 >> 13) & 0x01);
+        int shape = (attr0 >> 14) & 0x03;
+
+        // Attribute 1
+        int coordX = attr1 & 0x1FF;
+        if (coordX >> 8 == 0) {
+            oam.CoordinateX = coordX;
+        } else {
+            oam.CoordinateX = ((coordX ^ 0x1FF) + 1) * -1; // 9-bit negation + 1 (two's complement)
+        }
+
+        if (oam.HasRotationOrScaling) {
+            oam.RotationOrScalingGroup = (byte)((attr1 >> 9) & 0x1F);
+        } else {
+            // Bits 9-11 not used
+            oam.HorizontalFlip = ((attr1 >> 12) & 0x01) == 1;
+            oam.VerticalFlip = ((attr1 >> 13) & 0x01) == 1;
+        }
+
+        int sizeMode = (attr1 >> 14) & 0x03;
+
+        // Attribute 2
+        oam.TileIndex = (short)(attr2 & 0x3FF);
+        if (oam.PaletteMode == NitroPaletteMode.Palette16x16) {
+            oam.TileIndex *= 2;
+        }
+
+        oam.Layer = (attr2 >> 10) & 0x3;
+        oam.PaletteIndex = (byte)((attr2 >> 12) & 0x0F);
+
+        if (shape == 0) {
+            // Square
+            oam.Width = SizeMatrix[0, sizeMode];
+            oam.Height = SizeMatrix[0, sizeMode];
+        } else if (shape == 1) {
+            // Horizontal
+            oam.Width = SizeMatrix[1, sizeMode];
+            oam.Height = SizeMatrix[2, sizeMode];
+        } else if (shape == 2) {
+            // Vertical
+            oam.Width = SizeMatrix[2, sizeMode];
+            oam.Height = SizeMatrix[1, sizeMode];
+        }
+
+        return oam;
+    }
+
+    public static ObjectAttributeMemory ReadOam(this DataReader reader) =>
+        FromBinary(reader.ReadUInt16(), reader.ReadUInt16(), reader.ReadUInt16());
+
+    public static ObjectAttributeMemory[] ReadOams(this DataReader reader, int numOams)
+    {
+        var oams = new ObjectAttributeMemory[numOams];
+        for (int i = 0; i < numOams; i++) {
+            oams[i] = reader.ReadOam();
+        }
+
+        return oams;
+    }
+}

--- a/src/Texim/Sprites/IImageSegment.cs
+++ b/src/Texim/Sprites/IImageSegment.cs
@@ -31,7 +31,7 @@ public interface IImageSegment
 
     int Height { get; }
 
-    short TileIndex { get; }
+    int TileIndex { get; }
 
     bool HorizontalFlip { get; }
 

--- a/src/Texim/Sprites/ImageSegment2IndexedImageParams.cs
+++ b/src/Texim/Sprites/ImageSegment2IndexedImageParams.cs
@@ -27,5 +27,7 @@ public class ImageSegment2IndexedImageParams
 
     public IIndexedImage FullImage { get; set; }
 
+    public bool IsTiled { get; set; } = true;
+
     public int OutOfBoundsTileIndex { get; set; } = -1;
 }

--- a/src/Texim/Sprites/Sprite2IndexedImage.cs
+++ b/src/Texim/Sprites/Sprite2IndexedImage.cs
@@ -40,6 +40,7 @@ public class Sprite2IndexedImage :
             FullImage = parameters.FullImage,
             TileSize = parameters.TileSize,
             OutOfBoundsTileIndex = parameters.OutOfBoundsTileIndex,
+            IsTiled = parameters.IsTiled,
         };
         segmentConverter.Initialize(segmentParams);
     }
@@ -60,7 +61,7 @@ public class Sprite2IndexedImage :
             _ => throw new FormatException("Unknown relative position"),
         };
 
-        foreach (var segment in source.Segments.OrderBy(s => s.Layer)) {
+        foreach (var segment in source.Segments.OrderBy(s => s.Layer).Reverse()) {
             CopySegment(segment, pixelsSpan, source.Width, relativeX, relativeY);
         }
 

--- a/src/Texim/Sprites/Sprite2IndexedImageParams.cs
+++ b/src/Texim/Sprites/Sprite2IndexedImageParams.cs
@@ -27,6 +27,8 @@ public class Sprite2IndexedImageParams
 
     public System.Drawing.Size TileSize { get; set; } = new System.Drawing.Size(8, 8);
 
+    public bool IsTiled { get; set; } = true;
+
     public IIndexedImage FullImage { get; set; }
 
     public int OutOfBoundsTileIndex { get; set; } = -1;


### PR DESCRIPTION
### Description

- Implement NCER sprite format deserialization from binary into a collection of sprites (`Cell`). Including OAMs (reusables in some games).
- Implement basic export function of NCER sprites via CLI
  - It does not support some features of OAMs like mosaic, mode, rotation or scaling.
  - It does not support all the cell attributes defined (some unknown for now)
- Deserialize user extended and label names information from nitro formats
- Fix bug exporting sprites from bitmap pixels (non-swizzled)
- Fix bug with layers of sprites
- Fix `.editorconfig` for some IDEs.

### Example

Use the new converter `Binary2Ncer` to deserialize the binary stream into a node container. Its chidren have the `Cell` format that implements the interface `ISprite`. Each cell contains segments with the class `ObjectAttributeMemory` (OAM) that implements `IImageSegment`.
