### PR TITLE
Fix Indexed4BppBigEndian

### DIFF
--- a/src/Texim/Pixels/Indexed4BppBigEndian.cs
+++ b/src/Texim/Pixels/Indexed4BppBigEndian.cs
@@ -27,4 +27,6 @@ public class Indexed4BppBigEndian : Indexed4Bpp
     {
         Endianness = EndiannessMode.BigEndian;
     }
+    
+    public static new Indexed4Bpp Instance { get; } = new Indexed4BppBigEndian();
 }


### PR DESCRIPTION
### Description

We need a "new" `Instance` for `Indexed4BppBigEndian`. Otherwise, parent's one is taken and it uses `LittleEndian`.
