### PR TITLE
✨ Implement APIs to import sprites easily

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
-# Build outputs
+# Build outputs and IDEs
 obj/
 bin/
 artifacts/
 .vs/
+launchSettings.json
 
 # Build system
 tools/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,4 +23,5 @@
         "Unswizzle",
         "Vram"
     ],
+    "dotnet.defaultSolution": "src/Texim.sln",
 }

--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -163,6 +163,8 @@ dotnet_diagnostic.IDE1006.severity = warning
 ## Code analyzers
 ### .NET SDK
 dotnet_diagnostic.CA1303.severity = none # We don't translate exception and log messages from English
+dotnet_diagnostic.IDE45.severity = suggestion # 'if' statement can be simplified
+dotnet_diagnostic.IDE46.severity = suggestion # 'if' statement can be simplified
 
 ### StyleCop
 dotnet_diagnostic.SA1101.severity = none # Do not force to prefix local calls with 'this'

--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -10,7 +10,7 @@ indent_size = 4
 indent_style = space
 tab_width = 8
 trim_trailing_whitespace = true
-end_of_line = lf
+#end_of_line = lf
 insert_final_newline = true
 
 ## .NET style rules

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,23 +1,19 @@
 <Project>
-    <!-- Centralize dependency management -->
-    <ItemGroup>
-        <PackageVersion Include="Yarhl" Version="4.0.0-preview.153" />
-        <PackageVersion Include="System.Drawing.Common" Version="6.0.0" />
-        <PackageVersion Include="SixLabors.ImageSharp" Version="2.0.0" />
-
-        <PackageVersion Include="System.CommandLine" Version="2.0.0-beta1.21216.1" />
-        <PackageVersion Include="YamlDotNet" Version="11.2.1" />
-
-        <PackageVersion Include="BenchmarkDotNet" Version="0.13.1" />
-        <PackageVersion Include="NUnit" Version="3.12.0" />
-        <PackageVersion Include="NUnit3TestAdapter" Version="3.17.0" />
-        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="16.8.3"/>
-        <PackageVersion Include="coverlet.collector" Version="1.3.0" />
-
-        <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
-
-        <PackageVersion Include="StyleCop.Analyzers" Version="1.1.118" />
-        <PackageVersion Include="SonarAnalyzer.CSharp" Version="8.36.0.43782" />
-        <PackageVersion Include="Roslynator.Analyzers" Version="4.0.2" />
-    </ItemGroup>
+  <!-- Centralize dependency management -->
+  <ItemGroup>
+    <PackageVersion Include="Yarhl" Version="4.0.0-preview.185" />
+    <PackageVersion Include="System.Drawing.Common" Version="7.0.0" />
+    <PackageVersion Include="SixLabors.ImageSharp" Version="3.0.1" />
+    <PackageVersion Include="System.CommandLine" Version="2.0.0-beta1.21216.1" />
+    <PackageVersion Include="YamlDotNet" Version="13.1.1" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.13.7" />
+    <PackageVersion Include="NUnit" Version="3.13.3" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.0" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
+    <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.507" />
+    <PackageVersion Include="SonarAnalyzer.CSharp" Version="9.7.0.75501" />
+    <PackageVersion Include="Roslynator.Analyzers" Version="4.4.0" />
+  </ItemGroup>
 </Project>

--- a/src/Texim.Games/JumpUltimateStars/BinaryDstx2SpriteImage.cs
+++ b/src/Texim.Games/JumpUltimateStars/BinaryDstx2SpriteImage.cs
@@ -30,7 +30,7 @@ public class BinaryDstx2SpriteImage : IConverter<IBinary, NodeContainerFormat>
     private const string Stamp = "DSTX";
     private const int Type = 0x04;
 
-    private readonly BinaryDsig2IndexedPaletteImage dsigConverter = new ();
+    private readonly BinaryDsig2IndexedPaletteImage dsigConverter = new();
 
     public NodeContainerFormat Convert(IBinary source)
     {
@@ -47,7 +47,7 @@ public class BinaryDstx2SpriteImage : IConverter<IBinary, NodeContainerFormat>
             throw new FormatException($"Invalid stamp '{stamp}'");
         }
 
-        reader.ReadByte(); // unknown
+        _ = reader.ReadByte(); // unknown
         byte type = reader.ReadByte();
         if (type != Type) {
             throw new FormatException($"Invalid type: 0x{type:X2}");
@@ -55,7 +55,7 @@ public class BinaryDstx2SpriteImage : IConverter<IBinary, NodeContainerFormat>
 
         int numSegments = reader.ReadInt16();
         int dsigOffset = reader.ReadInt16();
-        reader.ReadInt16(); // unknown
+        _ = reader.ReadInt16(); // unknown
 
         var sprite = ReadSprite(reader, numSegments);
 

--- a/src/Texim.Games/JumpUltimateStars/KShapeSprites.cs
+++ b/src/Texim.Games/JumpUltimateStars/KShapeSprites.cs
@@ -25,7 +25,7 @@ using Yarhl.FileFormat;
 
 public class KShapeSprites : IFormat
 {
-    private readonly Dictionary<(int, int), Sprite> sprites = new ();
+    private readonly Dictionary<(int, int), Sprite> sprites = new();
 
     public void AddSprite(int group, int element, Sprite sprite)
     {

--- a/src/Texim.Games/Megaman/BinarySpr2Sprite.cs
+++ b/src/Texim.Games/Megaman/BinarySpr2Sprite.cs
@@ -195,7 +195,7 @@ public class BinarySpr2Sprite : IConverter<IBinary, NodeContainerFormat>
         return sprite;
     }
 
-    private (int width, int height) GetSize(int shape, int mode)
+    private (int Width, int Height) GetSize(int shape, int mode)
     {
         int[,] sizeMatrix = new int[3, 4] {
             { 8, 16, 32, 64 }, // Square
@@ -207,7 +207,7 @@ public class BinarySpr2Sprite : IConverter<IBinary, NodeContainerFormat>
             0 => (sizeMatrix[0, mode], sizeMatrix[0, mode]),
             1 => (sizeMatrix[1, mode], sizeMatrix[2, mode]),
             2 => (sizeMatrix[2, mode], sizeMatrix[1, mode]),
-            _ => throw new FormatException("Unknown size mode")
+            _ => throw new FormatException("Unknown size mode"),
         };
     }
 }

--- a/src/Texim.Games/Nitro/Binary2Ncer.cs
+++ b/src/Texim.Games/Nitro/Binary2Ncer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 SceneGate
+// Copyright (c) 2022 SceneGate
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -141,7 +141,7 @@ public class Binary2Ncer : NitroDeserializer<Ncer>
             uint attributeOffset = reader.ReadUInt32();
 
             reader.Stream.Position = sectionPos + attributeOffset;
-            model.Root.Children[i].GetFormatAs<Cell>() !
+            model.Root.Children[i].GetFormatAs<Cell>()!
                 .UserExtendedCellAttribute = reader.ReadUInt32();
         }
     }

--- a/src/Texim.Games/Nitro/Cell.cs
+++ b/src/Texim.Games/Nitro/Cell.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 SceneGate
+// Copyright (c) 2022 SceneGate
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -19,11 +19,9 @@
 // SOFTWARE.
 namespace Texim.Games.Nitro;
 
-using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Linq;
-using Sprites;
+using Texim.Sprites;
 
 /// <summary>
 /// Nitro sprite definition.

--- a/src/Texim.Games/Nitro/CellTileMappingKind.cs
+++ b/src/Texim.Games/Nitro/CellTileMappingKind.cs
@@ -29,6 +29,10 @@ public enum CellTileMappingKind
     Max,
 }
 
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "StyleCop.CSharp.DocumentationRules",
+    "SA1649:File name should match first type name",
+    Justification = "Extension of the same enum")]
 public static class CellTileMappingKindExtensions
 {
     public static int GetTileBlockSize(this CellTileMappingKind kind) => (1 << (5 + (int)kind)) / 64;

--- a/src/Texim.Games/Nitro/FullImage2NitroCell.cs
+++ b/src/Texim.Games/Nitro/FullImage2NitroCell.cs
@@ -1,0 +1,65 @@
+// Copyright (c) 2023 SceneGate
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+namespace Texim.Games.Nitro;
+
+using System;
+using System.Linq;
+using Texim.Images;
+using Texim.Sprites;
+using Yarhl.FileFormat;
+
+public class FullImage2NitroCell :
+    FullImage2Sprite,
+    IInitializer<FullImage2NitroCellParams>
+{
+    private FullImage2NitroCellParams parameters;
+
+    public void Initialize(FullImage2NitroCellParams parameters)
+    {
+        ArgumentNullException.ThrowIfNull(parameters);
+
+        this.parameters = parameters;
+        base.Initialize(parameters);
+    }
+
+    public override ISprite Convert(FullImage source)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(parameters);
+
+        var newSprite = base.Convert(source);
+
+        // Add the metadata from the original sprite.
+        // and convert the segments into OAMs.
+        var newCell = new Cell(parameters.ReferenceCell, newSprite.Segments) {
+            Width = newSprite.Width,
+            Height = newSprite.Height,
+        };
+
+        // Add missing info specific to OAMs.
+        foreach (var segment in newCell.Segments.OfType<ObjectAttributeMemory>()) {
+            segment.PaletteMode = parameters.Has8bppDepth
+                ? NitroPaletteMode.Palette256x1
+                : NitroPaletteMode.Palette16x16;
+        }
+
+        return newCell;
+    }
+}

--- a/src/Texim.Games/Nitro/FullImage2NitroCellParams.cs
+++ b/src/Texim.Games/Nitro/FullImage2NitroCellParams.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 SceneGate
+// Copyright (c) 2023 SceneGate
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -17,25 +17,20 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
-namespace Texim.Sprites;
+namespace Texim.Games.Nitro;
 
-public interface IImageSegment
+using Texim.Sprites;
+
+public record FullImage2NitroCellParams : FullImage2SpriteParams
 {
-    int Layer { get; }
+    /// <summary>
+    /// Gets the cell to use to copy the metadata into the new.
+    /// </summary>
+    public Cell ReferenceCell { get; init; }
 
-    int CoordinateX { get; }
-
-    int CoordinateY { get; }
-
-    int Width { get; }
-
-    int Height { get; }
-
-    int TileIndex { get; set; }
-
-    bool HorizontalFlip { get; }
-
-    bool VerticalFlip { get; }
-
-    byte PaletteIndex { get; }
+    /// <summary>
+    /// Gets a value indicating whether the cell image has the format 8 bits per pixel
+    /// or 4 bits per pixel.
+    /// </summary>
+    public bool Has8bppDepth { get; init; }
 }

--- a/src/Texim.Games/Nitro/Ncer2Binary.cs
+++ b/src/Texim.Games/Nitro/Ncer2Binary.cs
@@ -108,7 +108,7 @@ public class Ncer2Binary : NitroSerializer<Ncer>
         writer.Write(dataOffset);
 
         // Offsets
-        uint cellOffset = (uint)cells.Length * sizeof(uint) + dataOffset;
+        uint cellOffset = ((uint)cells.Length * sizeof(uint)) + dataOffset;
         for (int i = 0; i < cells.Length; i++) {
             writer.Write(cellOffset);
             cellOffset += sizeof(uint);

--- a/src/Texim.Games/Nitro/NitroSerializer.cs
+++ b/src/Texim.Games/Nitro/NitroSerializer.cs
@@ -60,7 +60,7 @@ namespace Texim.Games.Nitro
 
         protected void WriteLabelSection(DataWriter writer, IEnumerable<string> labels)
         {
-            var labelList = labels.ToArray();
+            string[] labelList = labels.ToArray();
             long sectionPos = writer.Stream.Position;
 
             // pre-fill offset table

--- a/src/Texim.Games/Nitro/ObjectAttributeMemory.cs
+++ b/src/Texim.Games/Nitro/ObjectAttributeMemory.cs
@@ -19,7 +19,7 @@
 // SOFTWARE.
 namespace Texim.Games.Nitro;
 
-using Sprites;
+using Texim.Sprites;
 
 /// <summary>
 /// Nitro sprite image segment format: Object attribute memory (OAM).

--- a/src/Texim.Tests/Colors/Bgr555Tests.cs
+++ b/src/Texim.Tests/Colors/Bgr555Tests.cs
@@ -1,7 +1,0 @@
-
-namespace Texim.Tests.Colors
-{
-    public class Bgr555Tests
-    {
-    }
-}

--- a/src/Texim.Tests/Texim.Tests.csproj
+++ b/src/Texim.Tests/Texim.Tests.csproj
@@ -12,6 +12,13 @@
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Colors\" />
   </ItemGroup>
 </Project>

--- a/src/Texim.Tool/Texim.Tool.csproj
+++ b/src/Texim.Tool/Texim.Tool.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <ProjectReference Include="../Texim/Texim.csproj" />
-    <ProjectReference Include="..\Texim.Games\Texim.Games.csproj" />
+    <ProjectReference Include="../Texim.Games/Texim.Games.csproj" />
 
     <PackageReference Include="System.CommandLine" />
     <PackageReference Include="YamlDotNet" />

--- a/src/Texim.sln
+++ b/src/Texim.sln
@@ -1,16 +1,24 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.6.30114.105
+# Visual Studio Version 17
+VisualStudioVersion = 17.7.34003.232
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Texim", "Texim\Texim.csproj", "{CEBAF316-25AF-4DF6-AC0D-0690E65EA986}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Texim", "Texim\Texim.csproj", "{CEBAF316-25AF-4DF6-AC0D-0690E65EA986}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Texim.Tool", "Texim.Tool\Texim.Tool.csproj", "{DC42B751-8302-400F-8528-9BB79DAE6B9D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Texim.Tool", "Texim.Tool\Texim.Tool.csproj", "{DC42B751-8302-400F-8528-9BB79DAE6B9D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Texim.PerformanceTest", "Texim.PerformanceTest\Texim.PerformanceTest.csproj", "{748619CD-2836-4E4C-BAD7-DD000737D0E6}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Texim.PerformanceTest", "Texim.PerformanceTest\Texim.PerformanceTest.csproj", "{748619CD-2836-4E4C-BAD7-DD000737D0E6}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Texim.Games", "Texim.Games\Texim.Games.csproj", "{BC0A3664-F79B-46AF-AA7D-D6D8C1CE2713}"
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Texim.Tests", "Texim.Tests\Texim.Tests.csproj", "{E2110B39-9BAD-4894-A273-0F86C18AF955}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Texim.Games", "Texim.Games\Texim.Games.csproj", "{BC0A3664-F79B-46AF-AA7D-D6D8C1CE2713}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Texim.Tests", "Texim.Tests\Texim.Tests.csproj", "{E2110B39-9BAD-4894-A273-0F86C18AF955}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{1C4853F3-CFB3-44AE-BDD6-D1417FCD3B4B}"
+	ProjectSection(SolutionItems) = preProject
+		Directory.Build.props = Directory.Build.props
+		Directory.Packages.props = Directory.Packages.props
+		nuget.config = nuget.config
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -20,9 +28,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{CEBAF316-25AF-4DF6-AC0D-0690E65EA986}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -85,5 +90,11 @@ Global
 		{E2110B39-9BAD-4894-A273-0F86C18AF955}.Release|x64.Build.0 = Release|Any CPU
 		{E2110B39-9BAD-4894-A273-0F86C18AF955}.Release|x86.ActiveCfg = Release|Any CPU
 		{E2110B39-9BAD-4894-A273-0F86C18AF955}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {0AD1A11F-E951-4AEC-B954-6F10B2036F5A}
 	EndGlobalSection
 EndGlobal

--- a/src/Texim/Formats/IndexedImage2Bitmap.cs
+++ b/src/Texim/Formats/IndexedImage2Bitmap.cs
@@ -36,8 +36,7 @@ namespace Texim.Formats
 
         public void Initialize(IndexedImageBitmapParams parameters)
         {
-            if (parameters == null)
-                throw new ArgumentNullException(nameof(parameters));
+            ArgumentNullException.ThrowIfNull(parameters);
 
             this.parameters = parameters;
         }
@@ -48,7 +47,7 @@ namespace Texim.Formats
                 throw new ArgumentNullException(nameof(source));
 
             // Preconvert to colors for faster iteration later
-            SixRgb[] PaletteToColors(IPalette pal) =>
+            static SixRgb[] PaletteToColors(IPalette pal) =>
                 pal.Colors.Select(c => c.ToImageSharpColor()).ToArray();
 
             SixRgb[][] palettes = (parameters.Palettes != null)

--- a/src/Texim/Images/ImageExtensions.cs
+++ b/src/Texim/Images/ImageExtensions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 SceneGate
+// Copyright (c) 2023 SceneGate
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -17,22 +17,31 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
-namespace Texim
+namespace Texim.Images;
+
+public static class ImageExtensions
 {
-    using System;
-    using System.Collections.Generic;
-
-    internal static class CollectionExtensions
+    public static FullImage SubImage(this IFullImage image, int startX, int startY, int width, int height)
     {
-        public static void Add<T>(this ICollection<T> collection, IEnumerable<T> source)
-        {
-            if (collection == null)
-                throw new ArgumentNullException(nameof(collection));
-            if (source == null)
-                throw new ArgumentNullException(nameof(source));
+        var subImage = new FullImage(width, height);
+        CopySubImage(image.Pixels, subImage.Pixels, image.Width, startX, startY, width, height);
+        return subImage;
+    }
 
-            foreach (var element in source) {
-                collection.Add(element);
+    public static IndexedImage SubImage(this IIndexedImage image, int startX, int startY, int width, int height)
+    {
+        var subImage = new IndexedImage(width, height);
+        CopySubImage(image.Pixels, subImage.Pixels, image.Width, startX, startY, width, height);
+        return subImage;
+    }
+
+    private static void CopySubImage<T>(T[] source, T[] destination, int sourceWidth, int startX, int startY, int width, int height)
+    {
+        int idx = 0;
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                int fullIndex = ((startY + y) * sourceWidth) + startX + x;
+                destination[idx++] = source[fullIndex];
             }
         }
     }

--- a/src/Texim/Pixels/Indexed4BppBigEndian.cs
+++ b/src/Texim/Pixels/Indexed4BppBigEndian.cs
@@ -27,6 +27,6 @@ public class Indexed4BppBigEndian : Indexed4Bpp
     {
         Endianness = EndiannessMode.BigEndian;
     }
-    
+
     public static new Indexed4Bpp Instance { get; } = new Indexed4BppBigEndian();
 }

--- a/src/Texim/Processing/FixedPaletteTileQuantizationResult.cs
+++ b/src/Texim/Processing/FixedPaletteTileQuantizationResult.cs
@@ -1,3 +1,22 @@
+// Copyright (c) 2023 SceneGate
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 namespace Texim.Processing;
 
 public class FixedPaletteTileQuantizationResult : QuantizationResult

--- a/src/Texim/Processing/MedianCutQuantization.cs
+++ b/src/Texim/Processing/MedianCutQuantization.cs
@@ -76,11 +76,11 @@ namespace Texim.Processing
 
             return new QuantizationResult {
                 Pixels = indexed,
-                Palettes = new PaletteCollection(palette)
+                Palettes = new PaletteCollection(palette),
             };
         }
 
-        private (PixelRef[], PixelRef[]) MedianCut(PixelRef[] bucket)
+        private (PixelRef[] FirstHalf, PixelRef[] LastHalf) MedianCut(PixelRef[] bucket)
         {
             long rangeRed = bucket.Max(c => c.Color.Red) - bucket.Min(c => c.Color.Red);
             long rangeGreen = bucket.Max(c => c.Color.Green) - bucket.Min(c => c.Color.Green);

--- a/src/Texim/Processing/QuantizationResult.cs
+++ b/src/Texim/Processing/QuantizationResult.cs
@@ -1,7 +1,7 @@
 namespace Texim.Processing;
 
-using Palettes;
-using Pixels;
+using Texim.Palettes;
+using Texim.Pixels;
 
 public class QuantizationResult
 {

--- a/src/Texim/Processing/QuantizationResult.cs
+++ b/src/Texim/Processing/QuantizationResult.cs
@@ -1,3 +1,22 @@
+// Copyright (c) 2023 SceneGate
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 namespace Texim.Processing;
 
 using Texim.Palettes;

--- a/src/Texim/Sprites/FullImage2Sprite.cs
+++ b/src/Texim/Sprites/FullImage2Sprite.cs
@@ -1,0 +1,115 @@
+// Copyright (c) 2023 SceneGate
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+namespace Texim.Sprites;
+
+using System;
+using System.Drawing;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Texim.Images;
+using Texim.Pixels;
+using Texim.Processing;
+using Yarhl.FileFormat;
+
+public class FullImage2Sprite :
+    IInitializer<FullImage2SpriteParams>,
+    IConverter<FullImage, ISprite>
+{
+    private FullImage2SpriteParams parameters;
+
+    public void Initialize(FullImage2SpriteParams parameters)
+    {
+        ArgumentNullException.ThrowIfNull(parameters);
+        this.parameters = parameters;
+    }
+
+    public virtual ISprite Convert(FullImage source)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(parameters);
+
+        // First segment the cell into smaller parts (OAMs).
+        // FUTURE: Check if the image fits in the existing cells, if so, re-use
+        // It's hard to segment properly our image as the original source image
+        // would have proper size (not full canvas) and proper layers. If we can
+        // re-use the original cells we will achieve better tile re-using.
+        var segmentation = new ImageSegmentation();
+        (Sprite newSprite, _) = segmentation.Segment(source);
+
+        // Now over its segments (OAMs), let's update its tile index and
+        // finding if there are matching sequences. Add them the new to the NCGR image.
+        foreach (ImageSegment segment in newSprite.Segments.Cast<ImageSegment>()) {
+            // Tiles are indexed pixels. We need to quantize first that section of the image.
+            FullImage segmentImage = source.SubImage(segment, parameters.RelativeCoordinates);
+
+            // We simulate like the sub-image is a big tile for the quantization so it finds only one palette.
+            // It will search for the best matching palette (e.g. cases of 16 palettes of 16 colors).
+            // LIMITATION: this may find a different palette than the original (case of palettes having same colors)
+            //    in that case it may not get the same indexes, so the compression will fail to find a matching tile.
+            //    Recommendation is to order colors in palettes, so even if they find different indexes are same.
+            // LIMITATION: We use the original palette, no new colors allowed.
+            var quantization = new FixedPaletteTileQuantization(
+                parameters.Palettes,
+                new Size(segment.Width, segment.Height),
+                segment.Width);
+            quantization.FirstAsTransparent = true;
+            var quantizationResult = (quantization.Quantize(segmentImage.Pixels) as FixedPaletteTileQuantizationResult)!;
+
+            // OAMs can have only one palette index, that's why we use a big tile.
+            segment.PaletteIndex = quantizationResult.PaletteIndexes[0];
+
+            // We had to swizzle. We can't compare lineal pixels as there isn't
+            // a constant "image width" that generates a valid sequence of lineal
+            // pixels. Each segment has a different width. That's why NCGR usually
+            // saves 0xFFFF as width. Having 8 as false width is the same as swizzling
+            // tileSize.Width == imageWidth -> nop operation (but we need a copy).
+            IndexedPixel[] segmentTiles;
+            if (parameters.IsImageTiled) {
+                var segmentSwizzler = new TileSwizzling<IndexedPixel>(segment.Width);
+                segmentTiles = segmentSwizzler.Swizzle(quantizationResult.Pixels);
+            } else {
+                segmentTiles = quantizationResult.Pixels;
+            }
+
+            // Now find unique pixels.
+            // We don't need to find unique individual tiles but the full sequence of tiles of the OAM.
+            // and put the start index in the OAM.
+            // Even if the image is not tiled, the OAM saves the index divided by tiles.
+            int tileIndex = PixelSequenceFinder.Search(
+                CollectionsMarshal.AsSpan(parameters.PixelSequences),
+                segmentTiles,
+                parameters.MinimumPixelsPerSegment);
+            if (tileIndex == -1) {
+                if (segmentTiles.Length < parameters.MinimumPixelsPerSegment) {
+                    int paddingPixelNum = parameters.MinimumPixelsPerSegment - segmentTiles.Length;
+                    segmentTiles = segmentTiles.Concat(new IndexedPixel[paddingPixelNum]).ToArray();
+                }
+
+                // Add sequence to the pixels.
+                segment.TileIndex = parameters.PixelSequences.Count / parameters.PixelsPerIndex;
+                parameters.PixelSequences.AddRange(segmentTiles);
+            } else {
+                segment.TileIndex = tileIndex / parameters.PixelsPerIndex;
+            }
+        }
+
+        return newSprite;
+    }
+}

--- a/src/Texim/Sprites/FullImage2SpriteParams.cs
+++ b/src/Texim/Sprites/FullImage2SpriteParams.cs
@@ -1,0 +1,63 @@
+// Copyright (c) 2023 SceneGate
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+namespace Texim.Sprites;
+
+using System.Collections.Generic;
+using Texim.Palettes;
+using Texim.Pixels;
+
+public record FullImage2SpriteParams
+{
+    /// <summary>
+    /// Gets the collection of palettes the converter will use to quantize the image.
+    /// It will not modify or append any new color or palette.
+    /// </summary>
+    public IPaletteCollection Palettes { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether the image pixels are tiled or not.
+    /// </summary>
+    public bool IsImageTiled { get; init; }
+
+    /// <summary>
+    /// Gets the sequence of tiles the converter will use to search and add
+    /// new pixels if not found.
+    /// </summary>
+    public List<IndexedPixel> PixelSequences { get; init; }
+
+    /// <summary>
+    /// Gets the minimum amount of pixels a sprite segment should have.
+    /// Usually this is the same as <see cref="PixelsPerIndex"/>, except in
+    /// NCER formats where it multiplies by a block size parameter.
+    /// </summary>
+    public int MinimumPixelsPerSegment { get; init; }
+
+    /// <summary>
+    /// Gets the amount of pixels each segment tile index increments.
+    /// Usually this is the tile size (64).
+    /// </summary>
+    public int PixelsPerIndex { get; init; }
+
+    /// <summary>
+    /// Gets the type of relative coordinates of the segments.
+    /// It must match with the value used in <see cref="Sprite2IndexedImageParams.RelativeCoordinates"/> when exporting.
+    /// </summary>
+    public SpriteRelativeCoordinatesKind RelativeCoordinates { get; init; } = SpriteRelativeCoordinatesKind.Center;
+}

--- a/src/Texim/Sprites/IImageSegmentation.cs
+++ b/src/Texim/Sprites/IImageSegmentation.cs
@@ -23,5 +23,5 @@ using Texim.Images;
 
 public interface IImageSegmentation
 {
-    (Sprite, FullImage) Segment(FullImage frame);
+    (Sprite Sprite, FullImage TrimmedImage) Segment(FullImage frame);
 }

--- a/src/Texim/Sprites/ImageSegment.cs
+++ b/src/Texim/Sprites/ImageSegment.cs
@@ -27,15 +27,15 @@ public class ImageSegment : IImageSegment
 
     public int CoordinateY { get; set; }
 
-    public int Width { get; init; }
+    public int Width { get; set; }
 
-    public int Height { get; init; }
+    public int Height { get; set; }
 
-    public int TileIndex { get; init; }
+    public int TileIndex { get; set; }
 
-    public bool HorizontalFlip { get; init; }
+    public bool HorizontalFlip { get; set; }
 
-    public bool VerticalFlip { get; init; }
+    public bool VerticalFlip { get; set; }
 
     public byte PaletteIndex { get; set; }
 }

--- a/src/Texim/Sprites/ImageSegmentation.cs
+++ b/src/Texim/Sprites/ImageSegmentation.cs
@@ -22,9 +22,8 @@ namespace Texim.Sprites;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using Colors;
+using Texim.Colors;
 using Texim.Images;
-using Texim.Pixels;
 
 public class ImageSegmentation : IImageSegmentation
 {
@@ -37,7 +36,7 @@ public class ImageSegmentation : IImageSegmentation
 
     private readonly int[,] splitMode = Modes[1];
 
-    public (Sprite, FullImage) Segment(FullImage frame)
+    public (Sprite Sprite, FullImage TrimmedImage) Segment(FullImage frame)
     {
         (int startX, int startY, FullImage trimmed) = TrimImage(frame);
 
@@ -103,7 +102,7 @@ public class ImageSegmentation : IImageSegmentation
         return segments;
     }
 
-    private (int width, int height) GetObjectSize(
+    private (int Width, int Height) GetObjectSize(
         FullImage frame,
         int x,
         int y,
@@ -158,6 +157,10 @@ public class ImageSegmentation : IImageSegmentation
         return (width, height);
     }
 
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "StyleCop.CSharp.OrderingRules",
+        "SA1204:Static elements should appear before instance elements",
+        Justification = "Readability of the algorithm")]
     private static bool IsValidSize(int width, int height)
     {
         if (width < 0 || width > 64 || width % 8 != 0) {
@@ -179,7 +182,7 @@ public class ImageSegmentation : IImageSegmentation
         return true;
     }
 
-    private static (int x, int y, FullImage trimmed) TrimImage(FullImage image)
+    private static (int X, int Y, FullImage Trimmed) TrimImage(FullImage image)
     {
         // Get border points to get dimensions
         int xStart = SearchNoTransparentPoint(image, 1);

--- a/src/Texim/Sprites/PixelSequenceFinder.cs
+++ b/src/Texim/Sprites/PixelSequenceFinder.cs
@@ -1,0 +1,66 @@
+// Copyright (c) 2023 SceneGate
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+namespace Texim.Sprites;
+
+using System;
+using Texim.Pixels;
+
+public static class PixelSequenceFinder
+{
+    public static int Search(
+        ReadOnlySpan<IndexedPixel> pixels,
+        ReadOnlySpan<IndexedPixel> sequence,
+        int blockSize)
+    {
+        int foundPos = -1;
+
+        for (int current = 0; current + blockSize < pixels.Length && foundPos == -1; current += blockSize) {
+            if (current + sequence.Length > pixels.Length) {
+                break;
+            }
+
+            foundPos = current;
+            if (HasSequence(pixels, sequence, current)) {
+                continue;
+            }
+
+            // TODO: try again flipping the sequence.
+            // In that case we may want to change the return type to a class.
+            foundPos = -1;
+        }
+
+        return foundPos;
+    }
+
+    private static bool HasSequence(
+        ReadOnlySpan<IndexedPixel> pixels,
+        ReadOnlySpan<IndexedPixel> sequence,
+        int startPos)
+    {
+        bool hasSequence = true;
+        for (int i = 0; i < sequence.Length && hasSequence; i++) {
+            if (pixels[startPos + i].Index != sequence[i].Index) {
+                hasSequence = false;
+            }
+        }
+
+        return hasSequence;
+    }
+}

--- a/src/Texim/Sprites/Sprite2IndexedImage.cs
+++ b/src/Texim/Sprites/Sprite2IndexedImage.cs
@@ -29,7 +29,7 @@ public class Sprite2IndexedImage :
     IInitializer<Sprite2IndexedImageParams>,
     IConverter<ISprite, IndexedImage>
 {
-    private readonly ImageSegment2IndexedImage segmentConverter = new ();
+    private readonly ImageSegment2IndexedImage segmentConverter = new();
     private Sprite2IndexedImageParams parameters;
 
     public void Initialize(Sprite2IndexedImageParams parameters)
@@ -92,7 +92,7 @@ public class Sprite2IndexedImage :
                     continue;
                 }
 
-                int outIdx = ((relativeY + segment.CoordinateY + y) * width) + (relativeX + segment.CoordinateX + x);
+                int outIdx = ((relativeY + segment.CoordinateY + y) * width) + relativeX + segment.CoordinateX + x;
                 output[outIdx] = pixel;
             }
         }

--- a/src/Texim/Sprites/SpriteImageExtensions.cs
+++ b/src/Texim/Sprites/SpriteImageExtensions.cs
@@ -1,0 +1,71 @@
+// Copyright (c) 2023 SceneGate
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+namespace Texim.Sprites;
+
+using System;
+using System.Drawing;
+using Texim.Images;
+using Texim.Pixels;
+
+public static class SpriteImageExtensions
+{
+    public static FullImage SubImage(this IFullImage image, IImageSegment segment, SpriteRelativeCoordinatesKind relativeCoordinates)
+    {
+        (int relativeX, int relativeY) = relativeCoordinates switch {
+            SpriteRelativeCoordinatesKind.TopLeft => (0, 0),
+            SpriteRelativeCoordinatesKind.Center => (image.Width / 2, image.Height / 2),
+            _ => throw new FormatException("Unknown relative position"),
+        };
+
+        return image.SubImage(
+            segment.CoordinateX + relativeX,
+            segment.CoordinateY + relativeY,
+            segment.Width,
+            segment.Height);
+    }
+
+    public static IndexedPixel[] GetSegmentPixels(this IndexedPixel[] source, IImageSegment segment, int pixelsPerIndex, int outOfBoundsTileIndex = -1)
+    {
+        var segmentPixels = new IndexedPixel[segment.Width * segment.Height];
+        Span<IndexedPixel> pixelsOut = segmentPixels;
+        Span<IndexedPixel> pixelsIn = source;
+
+        int numPixels = segment.Width * segment.Height;
+
+        int startIndex = segment.TileIndex * pixelsPerIndex;
+        if (startIndex + numPixels > pixelsIn.Length || startIndex < 0) {
+            if (outOfBoundsTileIndex == -1) {
+                throw new FormatException($"Required tile index {segment.TileIndex} is out of bounds");
+            } else {
+                startIndex = outOfBoundsTileIndex * pixelsPerIndex;
+            }
+        }
+
+        Span<IndexedPixel> tilesIn = pixelsIn.Slice(startIndex, numPixels);
+        for (int t = 0; t < numPixels; t++) {
+            pixelsOut[t] = new IndexedPixel(
+                tilesIn[t].Index,
+                tilesIn[t].Alpha,
+                segment.PaletteIndex);
+        }
+
+        return segmentPixels;
+    }
+}

--- a/src/Texim/Sprites/SpriteImageUpdater.cs
+++ b/src/Texim/Sprites/SpriteImageUpdater.cs
@@ -1,0 +1,71 @@
+// Copyright (c) 2023 SceneGate
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+namespace Texim.Sprites;
+
+using System;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Texim.Pixels;
+using Yarhl.FileFormat;
+
+public class SpriteImageUpdater :
+    IInitializer<SpriteImageUpdaterParams>,
+    IConverter<ISprite, ISprite>
+{
+    private SpriteImageUpdaterParams parameters;
+
+    public void Initialize(SpriteImageUpdaterParams parameters)
+    {
+        ArgumentNullException.ThrowIfNull(parameters);
+        this.parameters = parameters;
+    }
+
+    public ISprite Convert(ISprite source)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+
+        foreach (var segment in source.Segments) {
+            // No need to swizzle because the next methods retrieves the tiles in the same format from the image.
+            IndexedPixel[] segmentTiles = parameters.Image.Pixels.GetSegmentPixels(segment, parameters.PixelsPerIndex);
+
+            // Now find unique pixels.
+            // We don't need to find unique individual tiles but the full sequence of tiles of the OAM.
+            // and put the start index in the OAM.
+            int tileIndex = PixelSequenceFinder.Search(
+                CollectionsMarshal.AsSpan(parameters.PixelSequences),
+                segmentTiles,
+                parameters.MinimumPixelsPerSegment);
+            if (tileIndex == -1) {
+                if (segmentTiles.Length < parameters.MinimumPixelsPerSegment) {
+                    int paddingPixelNum = parameters.MinimumPixelsPerSegment - segmentTiles.Length;
+                    segmentTiles = segmentTiles.Concat(new IndexedPixel[paddingPixelNum]).ToArray();
+                }
+
+                // Add sequence to the pixels.
+                segment.TileIndex = parameters.PixelSequences.Count / parameters.PixelsPerIndex;
+                parameters.PixelSequences.AddRange(segmentTiles);
+            } else {
+                segment.TileIndex = tileIndex / parameters.PixelsPerIndex;
+            }
+        }
+
+        return source;
+    }
+}

--- a/src/Texim/Sprites/SpriteImageUpdaterParams.cs
+++ b/src/Texim/Sprites/SpriteImageUpdaterParams.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 SceneGate
+// Copyright (c) 2023 SceneGate
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -19,23 +19,33 @@
 // SOFTWARE.
 namespace Texim.Sprites;
 
-public interface IImageSegment
+using System.Collections.Generic;
+using Texim.Images;
+using Texim.Pixels;
+
+public record SpriteImageUpdaterParams
 {
-    int Layer { get; }
+    /// <summary>
+    /// Gets the image to update in the sprite.
+    /// </summary>
+    public IIndexedImage Image { get; init; }
 
-    int CoordinateX { get; }
+    /// <summary>
+    /// Gets the sequence of tiles the converter will use to search and add
+    /// new pixels if not found.
+    /// </summary>
+    public List<IndexedPixel> PixelSequences { get; init; }
 
-    int CoordinateY { get; }
+    /// <summary>
+    /// Gets the minimum amount of pixels a sprite segment should have.
+    /// Usually this is the same as <see cref="PixelsPerIndex"/>, except in
+    /// NCER formats where it multiplies by a block size parameter.
+    /// </summary>
+    public int MinimumPixelsPerSegment { get; init; }
 
-    int Width { get; }
-
-    int Height { get; }
-
-    int TileIndex { get; set; }
-
-    bool HorizontalFlip { get; }
-
-    bool VerticalFlip { get; }
-
-    byte PaletteIndex { get; }
+    /// <summary>
+    /// Gets the amount of pixels each segment tile index increments.
+    /// Usually this is the tile size (64).
+    /// </summary>
+    public int PixelsPerIndex { get; init; }
 }

--- a/src/Texim/Texim.csproj
+++ b/src/Texim/Texim.csproj
@@ -10,6 +10,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Texim.Games" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Yarhl" />
     <PackageReference Include="System.Drawing.Common" />
     <PackageReference Include="SixLabors.ImageSharp" />

--- a/src/nuget.config
+++ b/src/nuget.config
@@ -1,6 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
+    <clear/>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="SceneGate-Preview" value="https://pkgs.dev.azure.com/SceneGate/SceneGate/_packaging/SceneGate-Preview/nuget/v3/index.json" />
   </packageSources>
+  <packageSourceMapping>
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+    </packageSource>
+    <packageSource key="SceneGate-Preview">
+      <package pattern="Yarhl" />
+    </packageSource>
+  </packageSourceMapping>
 </configuration>


### PR DESCRIPTION
### Description

Previous PR brings the required algorithms to be able to import sprites. This PR refactors the required code into nice converter classes so it's easy for the end-user to use them.

Changes:
- Generic converter image -> Sprite: `FullImage2Sprite`
- Specialized converter image -> NDS sprite (Cell): `FullImage2NitroCell`
- Converter to update the image reference on an image segment: `SpriteImageUpdater`
- Extension methods to get a sub-image from `IIndexedImage` and `IFullImage`
- Extension methods to get the segment image and tiles
- Helper class `PixelSequenceFinder` to find a sequence of pixels
- Clean warnings and bump dependencies
- Fix nuget.config

### Example

Create a new sprite (nitro cell) from an image:

```csharp
PaletteCollection palette = ... // from an NCLR for instance
Image image = ... // from an NCGR for instance
Cell originalCell = ... // from original NCER to gets its metadata
int blockSize = 2 * 64; // from metadata of NCERs or just tile size
int pixelsPerTile = 64; // usually 8x8 tiles

var spriteConverterParameters = new FullImage2NitroCellParams {
    Palettes = palette,
    IsImageTiled = image.IsTiled,
    MinimumPixelsPerSegment = blockSize,
    PixelsPerIndex = pixelsPerTile,
    PixelSequences = uniqueTileSequences,
    RelativeCoordinates = SpriteRelativeCoordinatesKind.Center,
    Has8bppDepth = image.Format == NitroTextureFormat.Indexed8Bpp,
    ReferenceCell = originalCell,
};

using var sprite = NodeFactory.FromFile(spritePngPath, FileOpenMode.Read)
    .TransformWith<Bitmap2FullImage>()
    .TransformWith<FullImage2NitroCell, FullImage2NitroCellParams>(cellConverterParameters);
var newCell = sprite.GetFormatAs<Cell>()!; // put it inside a child of NCER
```

Re-import the image of an existing cell without editing the cell. For instance, to achieve better NCGR compression re-import cells (sprites) that won't be modified.

```csharp
var cellImageUpdaterParameters = new SpriteImageUpdaterParams {
    MinimumPixelsPerSegment = blockSize,
    PixelsPerIndex = pixelsPerTile,
    PixelSequences = uniqueTileSequences,
    Image = image,
};
var cellImageUpdater = new SpriteImageUpdater();
cellImageUpdater.Initialize(cellImageUpdaterParameters);
cellImageUpdater.Convert(originalCell);
```