### PR TITLE
🐛 Fix issue in pixel sequence finder and small improvements

### DIFF
--- a/src/Texim.Games/Nitro/Binary2Ncgr.cs
+++ b/src/Texim.Games/Nitro/Binary2Ncgr.cs
@@ -73,6 +73,7 @@ namespace Texim.Games.Nitro
             // file NCER or NSCR. In that case we assume the width is just one
             // tile, so 8.
             if (model.Width == 0xFFFF || model.Height == 0xFFFF) {
+                model.HasNullSize = true;
                 model.Width = 8; // tile width
                 model.Height = pixels.Length / model.Width;
             } else {

--- a/src/Texim.Games/Nitro/Ncgr.cs
+++ b/src/Texim.Games/Nitro/Ncgr.cs
@@ -36,6 +36,7 @@ namespace Texim.Games.Nitro
             Version = ncgr.Version;
             Height = ncgr.Height;
             Width = ncgr.Width;
+            HasNullSize = ncgr.HasNullSize;
             Pixels = ncgr.Pixels.ToArray();
             Format = ncgr.Format;
             TileMapping = ncgr.TileMapping;
@@ -76,6 +77,8 @@ namespace Texim.Games.Nitro
         public int Height { get; set; }
 
         public int Width { get; set; }
+
+        public bool HasNullSize { get; set; }
 
         public IndexedPixel[] Pixels { get; set; }
 

--- a/src/Texim.Games/Nitro/Ncgr2Binary.cs
+++ b/src/Texim.Games/Nitro/Ncgr2Binary.cs
@@ -35,8 +35,14 @@ namespace Texim.Games.Nitro
 
         private void WriteChar(DataWriter writer, Ncgr model)
         {
-            writer.Write((ushort)(model.Height / 8));
-            writer.Write((ushort)(model.Width / 8));
+            if (model.HasNullSize) {
+                writer.Write((ushort)0xFFFF);
+                writer.Write((ushort)0xFFFF);
+            } else {
+                writer.Write((ushort)(model.Height / 8));
+                writer.Write((ushort)(model.Width / 8));
+            }
+
             writer.Write((uint)model.Format);
             writer.Write((uint)model.TileMapping);
 

--- a/src/Texim/Sprites/FullImage2Sprite.cs
+++ b/src/Texim/Sprites/FullImage2Sprite.cs
@@ -50,8 +50,7 @@ public class FullImage2Sprite :
         // It's hard to segment properly our image as the original source image
         // would have proper size (not full canvas) and proper layers. If we can
         // re-use the original cells we will achieve better tile re-using.
-        var segmentation = new ImageSegmentation();
-        (Sprite newSprite, _) = segmentation.Segment(source);
+        (Sprite newSprite, _) = parameters.Segmentation.Segment(source);
 
         // Now over its segments (OAMs), let's update its tile index and
         // finding if there are matching sequences. Add them the new to the NCGR image.

--- a/src/Texim/Sprites/FullImage2SpriteParams.cs
+++ b/src/Texim/Sprites/FullImage2SpriteParams.cs
@@ -60,4 +60,10 @@ public record FullImage2SpriteParams
     /// It must match with the value used in <see cref="Sprite2IndexedImageParams.RelativeCoordinates"/> when exporting.
     /// </summary>
     public SpriteRelativeCoordinatesKind RelativeCoordinates { get; init; } = SpriteRelativeCoordinatesKind.Center;
+
+    /// <summary>
+    /// Gets the algorithm to segment the image.
+    /// By default, the one that works for Nintendo DS.
+    /// </summary>
+    public IImageSegmentation Segmentation { get; init; } = new ImageSegmentation();
 }

--- a/src/Texim/Sprites/ImageSegmentation.cs
+++ b/src/Texim/Sprites/ImageSegmentation.cs
@@ -25,6 +25,9 @@ using System.Collections.ObjectModel;
 using Texim.Colors;
 using Texim.Images;
 
+/// <summary>
+/// Image segmentation algorithm for Nintendo DS.
+/// </summary>
 public class ImageSegmentation : IImageSegmentation
 {
     // First value is the limit and the second is the side.

--- a/src/Texim/Sprites/PixelSequenceFinder.cs
+++ b/src/Texim/Sprites/PixelSequenceFinder.cs
@@ -31,7 +31,7 @@ public static class PixelSequenceFinder
     {
         int foundPos = -1;
 
-        for (int current = 0; current + blockSize < pixels.Length && foundPos == -1; current += blockSize) {
+        for (int current = 0; current + blockSize <= pixels.Length && foundPos == -1; current += blockSize) {
             if (current + sequence.Length > pixels.Length) {
                 break;
             }


### PR DESCRIPTION
### Description

- `PixelSequenceFinder` used for importing sprites was not detecting sequences at the end of the list. This causes an image unnecessary big.
- `FullImage2Sprite` accepts as parameter a custom segmentation algorithm (`IImageSegmentation`).
- NCGR files now writes back to disk a `null` width and height (`0xFFFF`) if it was the case in the original file.
