### PR TITLE
✨ 🐛  Improve sprite importer with cell re-using, flipping and bug fixes

### DIFF
--- a/src/Texim.Games/Nitro/FullImage2NitroCell.cs
+++ b/src/Texim.Games/Nitro/FullImage2NitroCell.cs
@@ -22,6 +22,7 @@ namespace Texim.Games.Nitro;
 using System;
 using System.Linq;
 using Texim.Images;
+using Texim.Pixels;
 using Texim.Sprites;
 using Yarhl.FileFormat;
 
@@ -53,13 +54,18 @@ public class FullImage2NitroCell :
             Height = newSprite.Height,
         };
 
-        // Add missing info specific to OAMs.
-        foreach (var segment in newCell.Segments.OfType<ObjectAttributeMemory>()) {
-            segment.PaletteMode = parameters.Has8bppDepth
+        return newCell;
+    }
+
+    protected override IImageSegment AssignImageToSegment(IImageSegment segmentStructure, IndexedPixel[] segmentTiles, byte paletteIndex)
+    {
+        var baseCell = base.AssignImageToSegment(segmentStructure, segmentTiles, paletteIndex);
+        var nitroCell = new ObjectAttributeMemory(baseCell);
+
+        nitroCell.PaletteMode = parameters.Has8bppDepth
                 ? NitroPaletteMode.Palette256x1
                 : NitroPaletteMode.Palette16x16;
-        }
 
-        return newCell;
+        return nitroCell;
     }
 }

--- a/src/Texim.Games/Nitro/FullImage2ReferenceNitroCell.cs
+++ b/src/Texim.Games/Nitro/FullImage2ReferenceNitroCell.cs
@@ -203,6 +203,11 @@ public class FullImage2ReferenceNitroCell :
                     // in case the color we get from the imported image comes from the bottom layer.
                     // If the overlayed images are same, take the color from drawing only the segment (no overlays)
                     subImage.Pixels[idx++] = referenceSegmentImage.Pixels[segmentIdx];
+                } else if (referenceImage.Pixels[segmentIdx].Alpha != 0 && referenceSegmentImage.Pixels[segmentIdx].Alpha == 0) {
+                    // If the original pixel with overlays is NOT transparent
+                    // but drawing only this segment (without overlays) is transparent.
+                    // then the pixel of our image is coming from a bottom layer, so ignore it for now.
+                    subImage.Pixels[idx++] = referenceSegmentImage.Pixels[segmentIdx];
                 } else {
                     subImage.Pixels[idx++] = image.Pixels[fullIndex];
                 }

--- a/src/Texim.Games/Nitro/FullImage2ReferenceNitroCell.cs
+++ b/src/Texim.Games/Nitro/FullImage2ReferenceNitroCell.cs
@@ -1,0 +1,328 @@
+// Copyright (c) 2023 SceneGate
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+namespace Texim.Games.Nitro;
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics.CodeAnalysis;
+using System.Drawing;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Texim.Colors;
+using Texim.Formats;
+using Texim.Images;
+using Texim.Pixels;
+using Texim.Processing;
+using Texim.Sprites;
+using Yarhl.FileFormat;
+
+public class FullImage2ReferenceNitroCell :
+    IConverter<FullImage, ISprite>,
+    IInitializer<FullImage2ReferenceNitroCellParams>
+{
+    private FullImage2ReferenceNitroCellParams parameters;
+
+    public void Initialize(FullImage2ReferenceNitroCellParams parameters)
+    {
+        ArgumentNullException.ThrowIfNull(parameters);
+
+        this.parameters = parameters;
+    }
+
+    public ISprite Convert(FullImage source)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(parameters);
+
+        var newSprite = new Cell(parameters.ReferenceCell, Array.Empty<IImageSegment>()) {
+            Width = parameters.ReferenceCell.Width,
+            Height = parameters.ReferenceCell.Height,
+        };
+
+        // Clone the image as we will modifying it.
+        FullImage newImage = new FullImage(source.Width, source.Height) {
+            Pixels = source.Pixels.ToArray(),
+        };
+
+        // Gets the original final image, so we can compare overlayed pixels
+        var sprite2Image = new Sprite2IndexedImage();
+        sprite2Image.Initialize(new Sprite2IndexedImageParams {
+            FullImage = parameters.Image,
+            IsTiled = parameters.IsImageTiled,
+            RelativeCoordinates = parameters.RelativeCoordinates,
+        });
+        FullImage originalSpriteImage = sprite2Image.Convert(parameters.ReferenceCell)
+            .CreateFullImage(parameters.Palettes);
+
+        ImageSegment2IndexedImage segment2Indexed = new ImageSegment2IndexedImage();
+        segment2Indexed.Initialize(new ImageSegment2IndexedImageParams {
+            FullImage = parameters.Image,
+            IsTiled = parameters.IsImageTiled,
+        });
+
+        // Start with the segments of the reference cell.
+        // We need to import from top to down drawing order as we will referencing the imported pixels from up layers.
+        var orderedSegments = parameters.ReferenceCell.Segments
+            .Select((x, idx) => new { Id = idx, Seg = x })
+            .OrderBy(x => x.Seg.Layer)
+            .ThenBy(x => x.Id)
+            .Select(x => x.Seg)
+            .ToArray();
+        for (int i = 0; i < orderedSegments.Length; i++) {
+            IImageSegment segment = orderedSegments[i];
+
+            // Get the original and new full image VISIBLE segments.
+            // if there are sections overlayed with another layer then we don't care about those pixels.
+            FullImage originalLayeredSegmentImage = originalSpriteImage.SubImage(segment, parameters.RelativeCoordinates);
+            FullImage originalSegmentImage = segment2Indexed.Convert(segment).CreateFullImage(parameters.Palettes, true);
+            FullImage segmentImage = PopVisiblePixels(
+                source,
+                newImage,
+                parameters.PixelSequences,
+                originalLayeredSegmentImage,
+                originalSegmentImage,
+                segment,
+                newSprite.Segments.Take(i).ToArray(),
+                parameters.RelativeCoordinates,
+                parameters.PixelsPerIndex);
+
+            // If our imported image has the same pixels as the original...
+            IndexedPixel[] segmentTiles;
+            byte paletteIdx;
+            if (HasSameVisiblePixels(segmentImage, originalSegmentImage)) {
+                // ... then we use the original tiles and palette.
+                segmentTiles = parameters.Image.Pixels.GetSegmentPixels(segment, parameters.PixelsPerIndex);
+                paletteIdx = segment.PaletteIndex;
+            } else {
+                // ... if they don't, then we quantize the new segment.
+                var quantization = new FixedPaletteTileQuantization(
+                    parameters.Palettes,
+                    new Size(segment.Width, segment.Height),
+                    segment.Width);
+                quantization.FirstAsTransparent = true;
+                var quantizationResult = (quantization.Quantize(segmentImage.Pixels) as FixedPaletteTileQuantizationResult)!;
+
+                paletteIdx = quantizationResult.PaletteIndexes[0];
+                if (parameters.IsImageTiled) {
+                    var segmentSwizzler = new TileSwizzling<IndexedPixel>(segment.Width);
+                    segmentTiles = segmentSwizzler.Swizzle(quantizationResult.Pixels);
+                } else {
+                    segmentTiles = quantizationResult.Pixels;
+                }
+            }
+
+            // Now let's put our tiles into the unique image segments pool.
+            var newSegment = AssignImageToSegment(segment, segmentTiles, paletteIdx);
+            newSprite.Segments.Add(newSegment);
+        }
+
+        // At this point, every non-transparent pixel is for new segments.
+        // so let's segment the new area.
+        (Sprite newSegmentsSprite, _) = parameters.Segmentation.Segment(newImage);
+
+        foreach (var newSegment in newSegmentsSprite.Segments) {
+            FullImage segmentImage = source.SubImage(newSegment, parameters.RelativeCoordinates);
+
+            var quantization = new FixedPaletteTileQuantization(
+                parameters.Palettes,
+                new Size(newSegment.Width, newSegment.Height),
+                newSegment.Width);
+            quantization.FirstAsTransparent = true;
+            var quantizationResult = (quantization.Quantize(segmentImage.Pixels) as FixedPaletteTileQuantizationResult)!;
+
+            IndexedPixel[] segmentTiles;
+            if (parameters.IsImageTiled) {
+                var segmentSwizzler = new TileSwizzling<IndexedPixel>(newSegment.Width);
+                segmentTiles = segmentSwizzler.Swizzle(quantizationResult.Pixels);
+            } else {
+                segmentTiles = quantizationResult.Pixels;
+            }
+
+            var newSegmentWithTile = AssignImageToSegment(newSegment, segmentTiles, quantizationResult.PaletteIndexes[0]);
+            newSprite.Segments.Add(newSegmentWithTile);
+        }
+
+        return newSprite;
+    }
+
+    private FullImage PopVisiblePixels(
+        FullImage image,
+        FullImage processedImage,
+        List<IndexedPixel> segmentsPixelBuffer,
+        FullImage referenceImage,
+        FullImage referenceSegmentImage,
+        IImageSegment segment,
+        IImageSegment[] topSegments,
+        SpriteRelativeCoordinatesKind relativeCoordinates,
+        int pixelsPerIndex)
+    {
+        (int relativeX, int relativeY) = relativeCoordinates switch {
+            SpriteRelativeCoordinatesKind.TopLeft => (0, 0),
+            SpriteRelativeCoordinatesKind.Center => (image.Width / 2, image.Height / 2),
+            _ => throw new FormatException("Unknown relative position"),
+        };
+
+        int startX = segment.CoordinateX + relativeX;
+        int startY = segment.CoordinateY + relativeY;
+        var subImage = new FullImage(segment.Width, segment.Height);
+
+        CompareNonTransparentPixels nonTransparentComparer = new();
+
+        int idx = 0;
+        for (int y = 0; y < segment.Height; y++) {
+            for (int x = 0; x < segment.Width; x++) {
+                int segmentIdx = idx;
+                int fullIndex = ((startY + y) * image.Width) + startX + x;
+
+                int canvasX = x + segment.CoordinateX;
+                int canvasY = y + segment.CoordinateY;
+                if (IsPixelFromTopSegments(canvasX, canvasY, topSegments, segmentsPixelBuffer, pixelsPerIndex)) {
+                    // As it's hidden, take the original color
+                    // we could also take the one from the image setting alpha to 0
+                    subImage.Pixels[idx++] = referenceSegmentImage.Pixels[segmentIdx];
+                } else if (nonTransparentComparer.Equals(image.Pixels[fullIndex], referenceImage.Pixels[segmentIdx])) {
+                    // This allows to set it as transparent as the original
+                    // in case the color we get from the imported image comes from the bottom layer.
+                    // If the overlayed images are same, take the color from drawing only the segment (no overlays)
+                    subImage.Pixels[idx++] = referenceSegmentImage.Pixels[segmentIdx];
+                } else {
+                    subImage.Pixels[idx++] = image.Pixels[fullIndex];
+
+                    // Set processed pixels as transparent
+                }
+
+                processedImage.Pixels[fullIndex] = new Rgb(22, 8, 93, 0);
+            }
+        }
+
+        return subImage;
+    }
+
+    private bool IsPixelFromTopSegments(int x, int y, IEnumerable<IImageSegment> segments, List<IndexedPixel> segmentsPixelBuffer, int pixelsPerIndex)
+    {
+        bool IsPixelInLayer(IImageSegment segment) =>
+            x >= segment.CoordinateX
+            && x < segment.CoordinateX + segment.Width
+            && y >= segment.CoordinateY
+            && y < segment.CoordinateY + segment.Height;
+
+        bool IsPixelVisible(IImageSegment segment)
+        {
+            // Another option would be to keep all the segment FullImage and compare against...
+            int startIndex = segment.TileIndex * pixelsPerIndex;
+            int segmentX = x - segment.CoordinateX;
+            int segmentY = y - segment.CoordinateY;
+            int index = startIndex + (segmentY * segment.Width) + segmentX;
+
+            return (segmentsPixelBuffer[index].Alpha != 0) && (segmentsPixelBuffer[index].Index > 0);
+        }
+
+        return segments.Any(seg => IsPixelInLayer(seg) && IsPixelVisible(seg));
+    }
+
+    private bool HasSameVisiblePixels(FullImage img1, FullImage img2)
+    {
+        return img1.Pixels.SequenceEqual(img2.Pixels, new CompareNonTransparentPixels());
+    }
+
+    private IImageSegment AssignImageToSegment(IImageSegment segmentStructure, IndexedPixel[] segmentTiles, byte paletteIndex)
+    {
+        var newSegment = new ImageSegment(segmentStructure);
+
+        // We only support one palette per segment.
+        newSegment.PaletteIndex = paletteIndex;
+
+        var segmentSize = new Size(segmentStructure.Width, segmentStructure.Height);
+        var (tileIndex, horizontalFlip, verticalFlip) = SearchTile(segmentTiles, segmentSize);
+        if (tileIndex == -1) {
+            if (segmentTiles.Length < parameters.MinimumPixelsPerSegment) {
+                int paddingPixelNum = parameters.MinimumPixelsPerSegment - segmentTiles.Length;
+                segmentTiles = segmentTiles.Concat(new IndexedPixel[paddingPixelNum]).ToArray();
+            }
+
+            // Add sequence to the pixels.
+            newSegment.TileIndex = parameters.PixelSequences.Count / parameters.PixelsPerIndex;
+            parameters.PixelSequences.AddRange(segmentTiles);
+        } else {
+            newSegment.TileIndex = tileIndex / parameters.PixelsPerIndex;
+        }
+
+        newSegment.HorizontalFlip = horizontalFlip;
+        newSegment.VerticalFlip = verticalFlip;
+
+        var nitroCell = new ObjectAttributeMemory(newSegment);
+
+        nitroCell.PaletteMode = parameters.Has8bppDepth
+                ? NitroPaletteMode.Palette256x1
+                : NitroPaletteMode.Palette16x16;
+
+        return nitroCell;
+    }
+
+    private (int TileIdx, bool HorizontalFlip, bool VerticalFlip) SearchTile(Span<IndexedPixel> segmentTiles, Size segmentSize)
+    {
+        var existingTiles = CollectionsMarshal.AsSpan(parameters.PixelSequences);
+
+        // We don't need to find unique individual tiles but the full sequence of tiles of the OAM.
+        // and put the start index in the OAM.
+        // Even if the image is not tiled, the OAM saves the index divided by tiles.
+        int tileIndex = PixelSequenceFinder.Search(existingTiles, segmentTiles, parameters.MinimumPixelsPerSegment);
+        if (tileIndex != -1) {
+            return (tileIndex, false, false);
+        }
+
+        segmentTiles.FlipHorizontal(segmentSize);
+        tileIndex = PixelSequenceFinder.Search(existingTiles, segmentTiles, parameters.MinimumPixelsPerSegment);
+        if (tileIndex != -1) {
+            return (tileIndex, true, false);
+        }
+
+        segmentTiles.FlipVertical(segmentSize);
+        tileIndex = PixelSequenceFinder.Search(existingTiles, segmentTiles, parameters.MinimumPixelsPerSegment);
+        if (tileIndex != -1) {
+            return (tileIndex, true, true);
+        }
+
+        segmentTiles.FlipHorizontal(segmentSize);
+        tileIndex = PixelSequenceFinder.Search(existingTiles, segmentTiles, parameters.MinimumPixelsPerSegment);
+        if (tileIndex != -1) {
+            return (tileIndex, false, true);
+        }
+
+        segmentTiles.FlipVertical(segmentSize);
+        return (-1, false, false);
+    }
+
+    private sealed class CompareNonTransparentPixels : IEqualityComparer<Rgb>
+    {
+        public bool Equals(Rgb x, Rgb y) =>
+            (x.Alpha == 0 && y.Alpha == 0) || x.Equals(y);
+
+        public int GetHashCode([DisallowNull] Rgb obj)
+        {
+            if (obj.Alpha == 0) {
+                return HashCode.Combine(obj.Alpha);
+            }
+
+            return obj.GetHashCode();
+        }
+    }
+}

--- a/src/Texim.Games/Nitro/FullImage2ReferenceNitroCellParams.cs
+++ b/src/Texim.Games/Nitro/FullImage2ReferenceNitroCellParams.cs
@@ -25,6 +25,20 @@ using Texim.Sprites;
 public record FullImage2ReferenceNitroCellParams : FullImage2SpriteParams
 {
     /// <summary>
+    /// Gets the file path (without extension) to write the original
+    /// and new images of layers that don't re-use the original image pixels
+    /// to debug the algorithm.
+    /// </summary>
+    public string DebugNewLayersPath { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether to prioritize new pixels in the
+    /// top layers (e.g. text over clean button) or put then in
+    /// the bottom layers (e.g. top layer is yellow border with transparent body).
+    /// </summary>
+    public bool ImportTopToBottom { get; init; } = true;
+
+    /// <summary>
     /// Gets the cell to use to copy the metadata into the new.
     /// </summary>
     public Cell ReferenceCell { get; init; }

--- a/src/Texim.Games/Nitro/FullImage2ReferenceNitroCellParams.cs
+++ b/src/Texim.Games/Nitro/FullImage2ReferenceNitroCellParams.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 SceneGate
+// Copyright (c) 2023 SceneGate
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -17,20 +17,26 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
-namespace Texim.Formats
+namespace Texim.Games.Nitro;
+
+using Texim.Images;
+using Texim.Sprites;
+
+public record FullImage2ReferenceNitroCellParams : FullImage2SpriteParams
 {
-    using SixLabors.ImageSharp.Formats;
-    using SixLabors.ImageSharp.Formats.Png;
-    using Texim.Palettes;
+    /// <summary>
+    /// Gets the cell to use to copy the metadata into the new.
+    /// </summary>
+    public Cell ReferenceCell { get; init; }
 
-    public class IndexedImageBitmapParams
-    {
-        public IImageEncoder Encoder { get; set; } = new PngEncoder();
+    /// <summary>
+    /// Gets a value indicating whether the cell image has the format 8 bits per pixel
+    /// or 4 bits per pixel.
+    /// </summary>
+    public bool Has8bppDepth { get; init; }
 
-        public IPalette Palette { get; set; }
-
-        public IPaletteCollection Palettes { get; set; }
-
-        public bool FirstColorAsTransparent { get; set; } = false;
-    }
+    /// <summary>
+    /// Gets the image to update in the sprite.
+    /// </summary>
+    public IIndexedImage Image { get; init; }
 }

--- a/src/Texim.Games/Nitro/FullImage2ReferenceNitroCellParams.cs
+++ b/src/Texim.Games/Nitro/FullImage2ReferenceNitroCellParams.cs
@@ -39,6 +39,12 @@ public record FullImage2ReferenceNitroCellParams : FullImage2SpriteParams
     public bool ImportTopToBottom { get; init; } = true;
 
     /// <summary>
+    /// Gets a value indicating whether this sprite supports horizontal and
+    /// vertical flipping.
+    /// </summary>
+    public bool SupportsFlipping { get; init; } = true;
+
+    /// <summary>
     /// Gets the cell to use to copy the metadata into the new.
     /// </summary>
     public Cell ReferenceCell { get; init; }

--- a/src/Texim.Games/Nitro/Ncer2Binary.cs
+++ b/src/Texim.Games/Nitro/Ncer2Binary.cs
@@ -63,6 +63,7 @@ public class Ncer2Binary : NitroSerializer<Ncer>
         }
 
         if (model.HasCellExtendedInfo) {
+            writer.WritePadding(0, 4);
             uint extendedOffset = (uint)(writer.Stream.Position - sectionPos);
             writer.Stream.PushToPosition(sectionPos + 0x14);
             writer.Write(extendedOffset);

--- a/src/Texim.Games/Nitro/ObjectAttributeMemory.cs
+++ b/src/Texim.Games/Nitro/ObjectAttributeMemory.cs
@@ -47,6 +47,15 @@ public class ObjectAttributeMemory : IImageSegment
         Mode = ObjectAttributeMemoryMode.Normal;
         IsMosaic = false;
         PaletteMode = NitroPaletteMode.Palette16x16;
+
+        if (other is ObjectAttributeMemory otherOam) {
+            HasRotationOrScaling = otherOam.HasRotationOrScaling;
+            RotationOrScalingGroup = otherOam.RotationOrScalingGroup;
+            HasDoubleSize = otherOam.HasDoubleSize;
+            IsDisabled = otherOam.IsDisabled;
+            Mode = otherOam.Mode;
+            IsMosaic = otherOam.IsMosaic;
+        }
     }
 
     public int Layer { get; set; }

--- a/src/Texim/Colors/Rgb.cs
+++ b/src/Texim/Colors/Rgb.cs
@@ -72,6 +72,9 @@ namespace Texim.Colors
 
         public byte Alpha { get; init; }
 
+        public readonly Rgb WithAlpha(byte alpha) =>
+            new Rgb(Red, Green, Blue, alpha);
+
         public readonly System.Drawing.Color ToColor() =>
             System.Drawing.Color.FromArgb(Alpha, Red, Green, Blue);
 

--- a/src/Texim/Formats/IndexedImage2Bitmap.cs
+++ b/src/Texim/Formats/IndexedImage2Bitmap.cs
@@ -74,9 +74,15 @@ namespace Texim.Formats
                             $"#{pixel.PaletteIndex} has {palette.Length}");
                     }
 
-                    SixRgb color = (pixel.Alpha != 255)
-                        ? new SixRgb(palette[pixel.Index].R, palette[pixel.Index].G, palette[pixel.Index].B, pixel.Alpha)
-                        : palette[pixel.Index];
+                    SixRgb color;
+                    if (parameters.FirstColorAsTransparent && pixel.Index == 0) {
+                        color = new SixRgb(palette[pixel.Index].R, palette[pixel.Index].G, palette[pixel.Index].B, 0);
+                    } else if (pixel.Alpha != 255) {
+                        color = new SixRgb(palette[pixel.Index].R, palette[pixel.Index].G, palette[pixel.Index].B, pixel.Alpha);
+                    } else {
+                        color = palette[pixel.Index];
+                    }
+
                     bitmap[x, y] = color;
                 }
             }

--- a/src/Texim/Images/IndexedImage.cs
+++ b/src/Texim/Images/IndexedImage.cs
@@ -19,6 +19,7 @@
 // SOFTWARE.
 namespace Texim.Images
 {
+    using Texim.Formats;
     using Texim.Palettes;
     using Texim.Pixels;
 
@@ -59,6 +60,12 @@ namespace Texim.Images
         public FullImage CreateFullImage(IPaletteCollection palettes)
         {
             fullImageConverter.Initialize(palettes);
+            return fullImageConverter.Convert(this);
+        }
+
+        public FullImage CreateFullImage(IPaletteCollection palettes, bool firstColorAsTransparent)
+        {
+            fullImageConverter.Initialize((palettes, firstColorAsTransparent));
             return fullImageConverter.Convert(this);
         }
     }

--- a/src/Texim/Sprites/FullImage2Sprite.cs
+++ b/src/Texim/Sprites/FullImage2Sprite.cs
@@ -32,31 +32,33 @@ public class FullImage2Sprite :
     IInitializer<FullImage2SpriteParams>,
     IConverter<FullImage, ISprite>
 {
-    private FullImage2SpriteParams parameters;
+    protected FullImage2SpriteParams Parameters { get; private set; }
 
     public void Initialize(FullImage2SpriteParams parameters)
     {
         ArgumentNullException.ThrowIfNull(parameters);
-        this.parameters = parameters;
+        Parameters = parameters;
     }
 
     public virtual ISprite Convert(FullImage source)
     {
         ArgumentNullException.ThrowIfNull(source);
-        ArgumentNullException.ThrowIfNull(parameters);
+        ArgumentNullException.ThrowIfNull(Parameters);
 
         // First segment the cell into smaller parts (OAMs).
         // FUTURE: Check if the image fits in the existing cells, if so, re-use
         // It's hard to segment properly our image as the original source image
         // would have proper size (not full canvas) and proper layers. If we can
         // re-use the original cells we will achieve better tile re-using.
-        (Sprite newSprite, _) = parameters.Segmentation.Segment(source);
+        (Sprite newSprite, _) = Parameters.Segmentation.Segment(source);
 
         // Now over its segments (OAMs), let's update its tile index and
         // finding if there are matching sequences. Add them the new to the NCGR image.
-        foreach (ImageSegment segment in newSprite.Segments.Cast<ImageSegment>()) {
+        for (int i = 0; i < newSprite.Segments.Count; i++) {
+            IImageSegment segment = newSprite.Segments[i];
+
             // Tiles are indexed pixels. We need to quantize first that section of the image.
-            FullImage segmentImage = source.SubImage(segment, parameters.RelativeCoordinates);
+            FullImage segmentImage = source.SubImage(segment, Parameters.RelativeCoordinates);
 
             // We simulate like the sub-image is a big tile for the quantization so it finds only one palette.
             // It will search for the best matching palette (e.g. cases of 16 palettes of 16 colors).
@@ -65,14 +67,11 @@ public class FullImage2Sprite :
             //    Recommendation is to order colors in palettes, so even if they find different indexes are same.
             // LIMITATION: We use the original palette, no new colors allowed.
             var quantization = new FixedPaletteTileQuantization(
-                parameters.Palettes,
+                Parameters.Palettes,
                 new Size(segment.Width, segment.Height),
                 segment.Width);
             quantization.FirstAsTransparent = true;
             var quantizationResult = (quantization.Quantize(segmentImage.Pixels) as FixedPaletteTileQuantizationResult)!;
-
-            // OAMs can have only one palette index, that's why we use a big tile.
-            segment.PaletteIndex = quantizationResult.PaletteIndexes[0];
 
             // We had to swizzle. We can't compare lineal pixels as there isn't
             // a constant "image width" that generates a valid sequence of lineal
@@ -80,35 +79,80 @@ public class FullImage2Sprite :
             // saves 0xFFFF as width. Having 8 as false width is the same as swizzling
             // tileSize.Width == imageWidth -> nop operation (but we need a copy).
             IndexedPixel[] segmentTiles;
-            if (parameters.IsImageTiled) {
+            if (Parameters.IsImageTiled) {
                 var segmentSwizzler = new TileSwizzling<IndexedPixel>(segment.Width);
                 segmentTiles = segmentSwizzler.Swizzle(quantizationResult.Pixels);
             } else {
                 segmentTiles = quantizationResult.Pixels;
             }
 
-            // Now find unique pixels.
-            // We don't need to find unique individual tiles but the full sequence of tiles of the OAM.
-            // and put the start index in the OAM.
-            // Even if the image is not tiled, the OAM saves the index divided by tiles.
-            int tileIndex = PixelSequenceFinder.Search(
-                CollectionsMarshal.AsSpan(parameters.PixelSequences),
-                segmentTiles,
-                parameters.MinimumPixelsPerSegment);
-            if (tileIndex == -1) {
-                if (segmentTiles.Length < parameters.MinimumPixelsPerSegment) {
-                    int paddingPixelNum = parameters.MinimumPixelsPerSegment - segmentTiles.Length;
-                    segmentTiles = segmentTiles.Concat(new IndexedPixel[paddingPixelNum]).ToArray();
-                }
-
-                // Add sequence to the pixels.
-                segment.TileIndex = parameters.PixelSequences.Count / parameters.PixelsPerIndex;
-                parameters.PixelSequences.AddRange(segmentTiles);
-            } else {
-                segment.TileIndex = tileIndex / parameters.PixelsPerIndex;
-            }
+            // Now find unique pixels and create new cell with metatada.
+            var newSegment = AssignImageToSegment(segment, segmentTiles, quantizationResult.PaletteIndexes[0]);
+            newSprite.Segments[i] = newSegment;
         }
 
         return newSprite;
+    }
+
+    protected virtual IImageSegment AssignImageToSegment(IImageSegment segmentStructure, IndexedPixel[] segmentTiles, byte paletteIndex)
+    {
+        var newSegment = new ImageSegment(segmentStructure);
+
+        // We only support one palette per segment.
+        newSegment.PaletteIndex = paletteIndex;
+
+        var segmentSize = new Size(segmentStructure.Width, segmentStructure.Height);
+        var (tileIndex, horizontalFlip, verticalFlip) = SearchTile(segmentTiles, segmentSize);
+        if (tileIndex == -1) {
+            if (segmentTiles.Length < Parameters.MinimumPixelsPerSegment) {
+                int paddingPixelNum = Parameters.MinimumPixelsPerSegment - segmentTiles.Length;
+                segmentTiles = segmentTiles.Concat(new IndexedPixel[paddingPixelNum]).ToArray();
+            }
+
+            // Add sequence to the pixels.
+            newSegment.TileIndex = Parameters.PixelSequences.Count / Parameters.PixelsPerIndex;
+            Parameters.PixelSequences.AddRange(segmentTiles);
+        } else {
+            newSegment.TileIndex = tileIndex / Parameters.PixelsPerIndex;
+        }
+
+        newSegment.HorizontalFlip = horizontalFlip;
+        newSegment.VerticalFlip = verticalFlip;
+
+        return newSegment;
+    }
+
+    private (int TileIdx, bool HorizontalFlip, bool VerticalFlip) SearchTile(Span<IndexedPixel> segmentTiles, Size segmentSize)
+    {
+        var existingTiles = CollectionsMarshal.AsSpan(Parameters.PixelSequences);
+
+        // We don't need to find unique individual tiles but the full sequence of tiles of the OAM.
+        // and put the start index in the OAM.
+        // Even if the image is not tiled, the OAM saves the index divided by tiles.
+        int tileIndex = PixelSequenceFinder.Search(existingTiles, segmentTiles, Parameters.MinimumPixelsPerSegment);
+        if (tileIndex != -1) {
+            return (tileIndex, false, false);
+        }
+
+        segmentTiles.FlipHorizontal(segmentSize);
+        tileIndex = PixelSequenceFinder.Search(existingTiles, segmentTiles, Parameters.MinimumPixelsPerSegment);
+        if (tileIndex != -1) {
+            return (tileIndex, true, false);
+        }
+
+        segmentTiles.FlipVertical(segmentSize);
+        tileIndex = PixelSequenceFinder.Search(existingTiles, segmentTiles, Parameters.MinimumPixelsPerSegment);
+        if (tileIndex != -1) {
+            return (tileIndex, true, true);
+        }
+
+        segmentTiles.FlipHorizontal(segmentSize);
+        tileIndex = PixelSequenceFinder.Search(existingTiles, segmentTiles, Parameters.MinimumPixelsPerSegment);
+        if (tileIndex != -1) {
+            return (tileIndex, false, true);
+        }
+
+        segmentTiles.FlipVertical(segmentSize);
+        return (-1, false, false);
     }
 }

--- a/src/Texim/Sprites/FullImage2SpriteParams.cs
+++ b/src/Texim/Sprites/FullImage2SpriteParams.cs
@@ -66,4 +66,13 @@ public record FullImage2SpriteParams
     /// By default, the one that works for Nintendo DS.
     /// </summary>
     public IImageSegmentation Segmentation { get; init; } = new ImageSegmentation();
+
+    /// <summary>
+    /// Gets a value indicating whether this sprite supports horizontal and
+    /// vertical flipping.
+    /// </summary>
+    /// <remarks>
+    /// Some games may not support this feature of the segments.
+    /// </remarks>
+    public bool SupportsFlipping { get; init; }
 }

--- a/src/Texim/Sprites/IImageSegment.cs
+++ b/src/Texim/Sprites/IImageSegment.cs
@@ -35,9 +35,9 @@ public interface IImageSegment : IFormat
 
     int TileIndex { get; set; }
 
-    bool HorizontalFlip { get; }
+    bool HorizontalFlip { get; set; }
 
-    bool VerticalFlip { get; }
+    bool VerticalFlip { get; set; }
 
     byte PaletteIndex { get; }
 }

--- a/src/Texim/Sprites/ImageSegment.cs
+++ b/src/Texim/Sprites/ImageSegment.cs
@@ -21,6 +21,23 @@ namespace Texim.Sprites;
 
 public class ImageSegment : IImageSegment
 {
+    public ImageSegment()
+    {
+    }
+
+    public ImageSegment(IImageSegment other)
+    {
+        Layer = other.Layer;
+        CoordinateX = other.CoordinateX;
+        CoordinateY = other.CoordinateY;
+        Width = other.Width;
+        Height = other.Height;
+        TileIndex = other.TileIndex;
+        HorizontalFlip = other.HorizontalFlip;
+        VerticalFlip = other.VerticalFlip;
+        PaletteIndex = other.PaletteIndex;
+    }
+
     public int Layer { get; set; }
 
     public int CoordinateX { get; set; }

--- a/src/Texim/Sprites/ImageSegmentation.cs
+++ b/src/Texim/Sprites/ImageSegmentation.cs
@@ -42,6 +42,15 @@ public class ImageSegmentation : IImageSegmentation
     public (Sprite Sprite, FullImage TrimmedImage) Segment(FullImage frame)
     {
         (int startX, int startY, FullImage trimmed) = TrimImage(frame);
+        if (trimmed is null) {
+            var emptySprite = new Sprite {
+                Width = 0,
+                Height = 0,
+                Segments = new Collection<IImageSegment>(),
+            };
+            var emptyImage = new FullImage(0, 0);
+            return (emptySprite, emptyImage);
+        }
 
         var segments = CreateObjects(trimmed, startX, startY, 0, 0, trimmed.Height);
 
@@ -190,6 +199,10 @@ public class ImageSegmentation : IImageSegmentation
         // Get border points to get dimensions
         int xStart = SearchNoTransparentPoint(image, 1);
         int yStart = SearchNoTransparentPoint(image, 0);
+        if (xStart == -1 && yStart == -1) {
+            return (-1, -1, null);
+        }
+
         int width = SearchNoTransparentPoint(image, 2) - xStart + 1;
         int height = SearchNoTransparentPoint(image, 3) - yStart + 1;
 

--- a/src/Texim/Sprites/PixelSequenceFinder.cs
+++ b/src/Texim/Sprites/PixelSequenceFinder.cs
@@ -20,6 +20,7 @@
 namespace Texim.Sprites;
 
 using System;
+using System.Drawing;
 using Texim.Pixels;
 
 public static class PixelSequenceFinder
@@ -41,12 +42,43 @@ public static class PixelSequenceFinder
                 continue;
             }
 
-            // TODO: try again flipping the sequence.
-            // In that case we may want to change the return type to a class.
             foundPos = -1;
         }
 
         return foundPos;
+    }
+
+    public static (int TileIdx, bool HorizontalFlip, bool VerticalFlip) SearchFlipping(
+        ReadOnlySpan<IndexedPixel> pixels,
+        Span<IndexedPixel> sequence,
+        int blockSize,
+        Size sequenceSize)
+    {
+        int tileIndex = Search(pixels, sequence, blockSize);
+        if (tileIndex != -1) {
+            return (tileIndex, false, false);
+        }
+
+        sequence.FlipHorizontal(sequenceSize);
+        tileIndex = Search(pixels, sequence, blockSize);
+        if (tileIndex != -1) {
+            return (tileIndex, true, false);
+        }
+
+        sequence.FlipVertical(sequenceSize);
+        tileIndex = Search(pixels, sequence, blockSize);
+        if (tileIndex != -1) {
+            return (tileIndex, true, true);
+        }
+
+        sequence.FlipHorizontal(sequenceSize);
+        tileIndex = Search(pixels, sequence, blockSize);
+        if (tileIndex != -1) {
+            return (tileIndex, false, true);
+        }
+
+        sequence.FlipVertical(sequenceSize);
+        return (-1, false, false);
     }
 
     private static bool HasSequence(

--- a/src/Texim/Sprites/PixelSequenceFinder.cs
+++ b/src/Texim/Sprites/PixelSequenceFinder.cs
@@ -50,7 +50,7 @@ public static class PixelSequenceFinder
 
     public static (int TileIdx, bool HorizontalFlip, bool VerticalFlip) SearchFlipping(
         ReadOnlySpan<IndexedPixel> pixels,
-        Span<IndexedPixel> sequence,
+        ReadOnlySpan<IndexedPixel> sequence,
         int blockSize,
         Size sequenceSize)
     {
@@ -59,25 +59,30 @@ public static class PixelSequenceFinder
             return (tileIndex, false, false);
         }
 
-        sequence.FlipHorizontal(sequenceSize);
-        tileIndex = Search(pixels, sequence, blockSize);
+        // Create a copy so we don't modify the originals
+        // anyway as we set the flag to flip, we shouldn't return/modify the pixels
+        // we are going to write.
+        var testSequence = sequence.ToArray().AsSpan();
+
+        testSequence.FlipHorizontal(sequenceSize);
+        tileIndex = Search(pixels, testSequence, blockSize);
         if (tileIndex != -1) {
             return (tileIndex, true, false);
         }
 
-        sequence.FlipVertical(sequenceSize);
-        tileIndex = Search(pixels, sequence, blockSize);
+        testSequence.FlipVertical(sequenceSize);
+        tileIndex = Search(pixels, testSequence, blockSize);
         if (tileIndex != -1) {
             return (tileIndex, true, true);
         }
 
-        sequence.FlipHorizontal(sequenceSize);
-        tileIndex = Search(pixels, sequence, blockSize);
+        testSequence.FlipHorizontal(sequenceSize);
+        tileIndex = Search(pixels, testSequence, blockSize);
         if (tileIndex != -1) {
             return (tileIndex, false, true);
         }
 
-        sequence.FlipVertical(sequenceSize);
+        testSequence.FlipVertical(sequenceSize);
         return (-1, false, false);
     }
 

--- a/src/Texim/Sprites/SpriteImageUpdater.cs
+++ b/src/Texim/Sprites/SpriteImageUpdater.cs
@@ -57,11 +57,10 @@ public class SpriteImageUpdater :
 
     protected virtual void AssignImageToSegment(IImageSegment segment, IndexedPixel[] segmentTiles)
     {
-        var segmentSize = new Size(segment.Width, segment.Height);
         var existingTiles = CollectionsMarshal.AsSpan(parameters.PixelSequences);
-        var tileSearch = PixelSequenceFinder.SearchFlipping(existingTiles, segmentTiles, parameters.MinimumPixelsPerSegment, segmentSize);
+        int tileIdx = PixelSequenceFinder.Search(existingTiles, segmentTiles, parameters.MinimumPixelsPerSegment);
 
-        if (tileSearch.TileIdx == -1) {
+        if (tileIdx == -1) {
             if (segmentTiles.Length < parameters.MinimumPixelsPerSegment) {
                 int paddingPixelNum = parameters.MinimumPixelsPerSegment - segmentTiles.Length;
                 segmentTiles = segmentTiles.Concat(new IndexedPixel[paddingPixelNum]).ToArray();
@@ -71,10 +70,7 @@ public class SpriteImageUpdater :
             segment.TileIndex = parameters.PixelSequences.Count / parameters.PixelsPerIndex;
             parameters.PixelSequences.AddRange(segmentTiles);
         } else {
-            segment.TileIndex = tileSearch.TileIdx / parameters.PixelsPerIndex;
+            segment.TileIndex = tileIdx / parameters.PixelsPerIndex;
         }
-
-        segment.HorizontalFlip = tileSearch.HorizontalFlip;
-        segment.VerticalFlip = tileSearch.VerticalFlip;
     }
 }

--- a/src/Texim/Sprites/SpriteImageUpdater.cs
+++ b/src/Texim/Sprites/SpriteImageUpdater.cs
@@ -46,6 +46,16 @@ public class SpriteImageUpdater :
             // No need to swizzle because the next methods retrieves the tiles in the same format from the image.
             IndexedPixel[] segmentTiles = parameters.Image.Pixels.GetSegmentPixels(segment, parameters.PixelsPerIndex);
 
+            // Apply the flipping so it doesn't break the next algo searching the data.
+            Span<IndexedPixel> spanSegment = segmentTiles;
+            if (segment.HorizontalFlip) {
+                spanSegment.FlipHorizontal(new Size(segment.Width, segment.Height));
+            }
+
+            if (segment.VerticalFlip) {
+                spanSegment.FlipVertical(new Size(segment.Width, segment.Height));
+            }
+
             // Now find unique pixels.
             // We don't need to find unique individual tiles but the full sequence of tiles of the OAM.
             // and put the start index in the OAM.
@@ -57,10 +67,11 @@ public class SpriteImageUpdater :
 
     protected virtual void AssignImageToSegment(IImageSegment segment, IndexedPixel[] segmentTiles)
     {
+        var segmentSize = new Size(segment.Width, segment.Height);
         var existingTiles = CollectionsMarshal.AsSpan(parameters.PixelSequences);
-        int tileIdx = PixelSequenceFinder.Search(existingTiles, segmentTiles, parameters.MinimumPixelsPerSegment);
+        var tileSearch = PixelSequenceFinder.SearchFlipping(existingTiles, segmentTiles, parameters.MinimumPixelsPerSegment, segmentSize);
 
-        if (tileIdx == -1) {
+        if (tileSearch.TileIdx == -1) {
             if (segmentTiles.Length < parameters.MinimumPixelsPerSegment) {
                 int paddingPixelNum = parameters.MinimumPixelsPerSegment - segmentTiles.Length;
                 segmentTiles = segmentTiles.Concat(new IndexedPixel[paddingPixelNum]).ToArray();
@@ -70,7 +81,10 @@ public class SpriteImageUpdater :
             segment.TileIndex = parameters.PixelSequences.Count / parameters.PixelsPerIndex;
             parameters.PixelSequences.AddRange(segmentTiles);
         } else {
-            segment.TileIndex = tileIdx / parameters.PixelsPerIndex;
+            segment.TileIndex = tileSearch.TileIdx / parameters.PixelsPerIndex;
         }
+
+        segment.HorizontalFlip = tileSearch.HorizontalFlip;
+        segment.VerticalFlip = tileSearch.VerticalFlip;
     }
 }

--- a/src/Texim/Sprites/SpriteImageUpdaterParams.cs
+++ b/src/Texim/Sprites/SpriteImageUpdaterParams.cs
@@ -48,4 +48,13 @@ public record SpriteImageUpdaterParams
     /// Usually this is the tile size (64).
     /// </summary>
     public int PixelsPerIndex { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether this sprite supports horizontal and
+    /// vertical flipping.
+    /// </summary>
+    /// <remarks>
+    /// Some games may not support this feature of the segments.
+    /// </remarks>
+    public bool SupportsFlipping { get; init; }
 }


### PR DESCRIPTION
### Description

- ✨ Create new image to sprite converter that re-use the original segmentation of NCER. This allows better pixel re-use as we can guess the pixels from hidden layers.
- 🐛 Fix missing padding in NCER serialization that could cause a game crash
- ✨ Implement tile searching with horizontal and vertical flipping.
- 🐛 Fix OAMs were not copying rotation and scaling attributes
- ✨ Improve bitmap converters to convert the first color as transparency.

_Compression_ difference thanks to pixel re-using in hidden layers (e.g. clean button). Less is better, negative is better compression than original. Tested in Pokémon Conquest with its 41 sprite containers (hundreds sprites in some of them).
| Sprite container                                     | Pixel diff before | Pixel diff after |
| ---------------------------------------------------- | ----------------- | ---------------- |
| common/11_01_parts_usual_up.G2DR                     | -1024 (-7.84%)    | -1024 (-7.84%)   |
| common/11_02_parts_ikusa_tutorial_lo.G2DR            | -4608 (-18.18%)   | +1536 (6.06%)    |
| common/11_02_parts_ransemap_tutorial_lo.G2DR         | -512 (-5.00%)     | +1280 (12.50%)   |
| common/11_02_parts_usual_lo.G2DR                     | -1024 (-7.84%)    | -1024 (-7.84%)   |
| common/11_03_parts_ikusamap_up.G2DR                  | -10240 (-8.39%)   | -5376 (-4.40%)   |
| common/11_04_parts_collectioncount_up.G2DR           | +12032 (45.63%)   | +512 (1.94%)     |
| config/07_01_parts_config_lo.G2DR                    | +4096 (17.78%)    | +7680 (33.33%)   |
| connect/05_00_parts_hanyou_lo.G2DR                   | +14848 (70.73%)   | +4096 (19.51%)   |
| connect/05_03_parts_parentchildselect_lo.G2DR        | -1280 (-9.62%)    | -256 (-1.92%)    |
| connect/05_04_parts_setuzoku_info_base_up.G2DR       | -512 (-3.57%)     | -512 (-3.57%)    |
| connect/05_11_parts_teamset_lo.G2DR                  | +4608 (39.13%)    | +512 (4.35%)     |
| connect/05_15_parts_communicationbushoselect_lo.G2DR | +9216 (15.06%)    | +0 (0.00%)       |
| episodeselect/02_02_parts_episodeexplain_up.G2DR     | +512 (28.57%)     | +512 (28.57%)    |
| ikusa/04_01_parts_ikusamap_lo.G2DR                   | +21760 (20.83%)   | -3840 (-3.68%)   |
| ikusa/result/04_01_parts_ikusaresult_lo.G2DR         | -768 (-1.36%)     | -4096 (-7.24%)   |
| ikusa/result/04_01_parts_tsushin_ikusaresult_lo.G2DR | +1536 (3.51%)     | -2816 (-6.43%)   |
| ikusa/start/04_01_parts_ikusastart_lo.G2DR           | -256 (-0.40%)     | +0 (0.00%)       |
| ikusa/winlose/04_01_parts_defeat_lo.G2DR             | -9984 (-46.99%)   | +0 (0.00%)       |
| ikusa/winlose/04_01_parts_victory_lo.G2DR            | -7680 (-38.96%)   | +0 (0.00%)       |
| info/06_00_parts_bushopokemoninfo_up.G2DR            | +35840 (24.65%)   | -4352 (-2.99%)   |
| info/06_03_parts_bushopokemoninfo_lo.G2DR            | +41472 (57.86%)   | +5888 (8.21%)    |
| info/06_04_parts_busholist_lo.G2DR                   | +8704 (14.11%)    | -256 (-0.41%)    |
| info/06_06_parts_typesearch_lo.G2DR                  | +32000 (48.26%)   | +2304 (3.47%)    |
| playermake/01_01_parts_boygirlselect_lo.G2DR         | -256 (-1.39%)     | -256 (-1.39%)    |
| playermake/01_03_parts_nameinput_lo.G2DR             | +14592 (107.55%)  | +4352 (32.08%)   |
| strategy/03_00_parts_kuniinfo_up.G2DR                | +1280 (4.17%)     | +768 (2.50%)     |
| strategy/03_01_parts_ransemap_lo.G2DR                | +154624 (145.54%) | -5888 (-5.54%)   |
| strategy/03_01_parts_shiromap_lo.G2DR                | +114176 (153.79%) | -4864 (-6.55%)   |
| strategy/03_04_parts_institutioninfo_up.G2DR         | +11776 (19.49%)   | +768 (1.27%)     |
| strategy/03_08_parts_shopinfo_up.G2DR                | -2816 (-8.53%)    | +0 (0.00%)       |
| strategy/03_09_parts_itemselect_lo.G2DR              | +35328 (47.10%)   | -5632 (-7.51%)   |
| title/00_00_parts_logo_up.G2DR                       | -12928 (-31.56%)  | +0 (0.00%)       |
| title/00_05_parts_title_lo.G2DR                      | -128 (-0.28%)     | +1280 (2.80%)    |
| title/00_06_parts_titlemenu_lo.G2DR                  | +9472 (18.14%)    | -5632 (-10.78%)  |
| title/00_07_parts_gallerytop_lo.G2DR                 | +5376 (48.84%)    | +512 (4.65%)     |
| title/00_08_parts_pokemongallery_lo.G2DR             | +6144 (18.90%)    | +3584 (11.02%)   |
| title/00_10_parts_pokemonparameter_lo.G2DR           | -10752 (-14.38%)  | -4096 (-5.48%)   |
| title/00_11_parts_pokemonotherinfo_lo.G2DR           | -3072 (-5.50%)    | -256 (-0.46%)    |
| title/00_12_parts_bushogallery_lo.G2DR               | +6144 (19.67%)    | +1280 (4.10%)    |
| title/00_14_parts_bushoparameter_lo.G2DR             | +7680 (17.86%)    | -768 (-1.79%)    |
| title/00_15_parts_bushobestmatch_lo.G2DR             | +2816 (18.64%)    | +512 (3.39%)     |

Test | # images larger than original | Worst compression ratio | Best compression ratio | Average compression
--- | --- | --- | --- | ---
Before | 24 | 153.79 % | -46.99 % | 19.41 %
After | 17 | 33.33% | -10.78 % | 2.29 %

### Example

Use the new converter `FullImage2ReferenceNitroCell` similar to the others.
Note that for now it's only available for Nitro (NCER) format.

