### PR TITLE
Migrate converters to Yarhl v4.0

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,21 +1,21 @@
 <Project>
   <!-- Centralize dependency management -->
   <ItemGroup>
-    <PackageVersion Include="Yarhl" Version="4.0.0-preview.185" />
-    <PackageVersion Include="System.Drawing.Common" Version="7.0.0" />
-    <PackageVersion Include="SixLabors.ImageSharp" Version="3.0.1" />
+    <PackageVersion Include="Yarhl" Version="4.0.0-preview.283" />
+    <PackageVersion Include="System.Drawing.Common" Version="8.0.0" />
+    <PackageVersion Include="SixLabors.ImageSharp" Version="3.0.2" />
     <PackageVersion Include="BitMiracle.LibTiff.NET" Version="2.4.649" />
-	<PackageVersion Include="Magick.NET-Q16-HDRI-AnyCPU" Version="13.2.0" />
+    <PackageVersion Include="Magick.NET-Q16-HDRI-AnyCPU" Version="13.4.0" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta1.21216.1" />
-    <PackageVersion Include="YamlDotNet" Version="13.1.1" />
-    <PackageVersion Include="BenchmarkDotNet" Version="0.13.7" />
-    <PackageVersion Include="NUnit" Version="3.13.3" />
+    <PackageVersion Include="YamlDotNet" Version="13.7.1" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.13.10" />
+    <PackageVersion Include="NUnit" Version="4.0.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.507" />
-    <PackageVersion Include="SonarAnalyzer.CSharp" Version="9.7.0.75501" />
-    <PackageVersion Include="Roslynator.Analyzers" Version="4.4.0" />
+    <PackageVersion Include="SonarAnalyzer.CSharp" Version="9.14.0.81108" />
+    <PackageVersion Include="Roslynator.Analyzers" Version="4.6.4" />
   </ItemGroup>
 </Project>

--- a/src/Texim.Games/Nitro/FullImage2NitroCell.cs
+++ b/src/Texim.Games/Nitro/FullImage2NitroCell.cs
@@ -27,14 +27,14 @@ using Texim.Sprites;
 
 public class FullImage2NitroCell : FullImage2Sprite
 {
-    private FullImage2NitroCellParams parameters;
+    private readonly FullImage2NitroCellParams parameters;
 
-    private bool hasRotationScaling;
-    private byte rotationScalingGroup;
-    private bool hasDoubleSize;
-    private bool isDisabled;
-    private bool isMosaic;
-    private ObjectAttributeMemoryMode memoryMode;
+    private readonly bool hasRotationScaling;
+    private readonly byte rotationScalingGroup;
+    private readonly bool hasDoubleSize;
+    private readonly bool isDisabled;
+    private readonly bool isMosaic;
+    private readonly ObjectAttributeMemoryMode memoryMode;
 
     public FullImage2NitroCell(FullImage2NitroCellParams parameters)
         : base(parameters)

--- a/src/Texim.Games/Nitro/FullImage2NitroCell.cs
+++ b/src/Texim.Games/Nitro/FullImage2NitroCell.cs
@@ -24,11 +24,8 @@ using System.Linq;
 using Texim.Images;
 using Texim.Pixels;
 using Texim.Sprites;
-using Yarhl.FileFormat;
 
-public class FullImage2NitroCell :
-    FullImage2Sprite,
-    IInitializer<FullImage2NitroCellParams>
+public class FullImage2NitroCell : FullImage2Sprite
 {
     private FullImage2NitroCellParams parameters;
 
@@ -39,12 +36,12 @@ public class FullImage2NitroCell :
     private bool isMosaic;
     private ObjectAttributeMemoryMode memoryMode;
 
-    public void Initialize(FullImage2NitroCellParams parameters)
+    public FullImage2NitroCell(FullImage2NitroCellParams parameters)
+        : base(parameters)
     {
         ArgumentNullException.ThrowIfNull(parameters);
 
         this.parameters = parameters;
-        base.Initialize(parameters);
 
         // We can only guess the original metadata if every original OAMs have it
         // otherwise, as original and new OAMs may differ, it's hard to know.

--- a/src/Texim.Games/Nitro/FullImage2ReferenceNitroCell.cs
+++ b/src/Texim.Games/Nitro/FullImage2ReferenceNitroCell.cs
@@ -33,13 +33,11 @@ using Texim.Processing;
 using Texim.Sprites;
 using Yarhl.FileFormat;
 
-public class FullImage2ReferenceNitroCell :
-    IConverter<FullImage, ISprite>,
-    IInitializer<FullImage2ReferenceNitroCellParams>
+public class FullImage2ReferenceNitroCell : IConverter<FullImage, ISprite>
 {
-    private FullImage2ReferenceNitroCellParams parameters;
+    private readonly FullImage2ReferenceNitroCellParams parameters;
 
-    public void Initialize(FullImage2ReferenceNitroCellParams parameters)
+    public FullImage2ReferenceNitroCell(FullImage2ReferenceNitroCellParams parameters)
     {
         ArgumentNullException.ThrowIfNull(parameters);
 
@@ -49,7 +47,6 @@ public class FullImage2ReferenceNitroCell :
     public ISprite Convert(FullImage source)
     {
         ArgumentNullException.ThrowIfNull(source);
-        ArgumentNullException.ThrowIfNull(parameters);
 
         var newSprite = new Cell(parameters.ReferenceCell, Array.Empty<IImageSegment>()) {
             Width = parameters.ReferenceCell.Width,

--- a/src/Texim.Games/Nitro/FullImage2ReferenceNitroCell.cs
+++ b/src/Texim.Games/Nitro/FullImage2ReferenceNitroCell.cs
@@ -62,8 +62,7 @@ public class FullImage2ReferenceNitroCell :
         };
 
         // Gets the original final image, so we can compare overlayed pixels
-        var sprite2Image = new Sprite2IndexedImage();
-        sprite2Image.Initialize(new Sprite2IndexedImageParams {
+        var sprite2Image = new Sprite2IndexedImage(new Sprite2IndexedImageParams {
             FullImage = parameters.Image,
             IsTiled = parameters.IsImageTiled,
             RelativeCoordinates = parameters.RelativeCoordinates,
@@ -71,8 +70,7 @@ public class FullImage2ReferenceNitroCell :
         FullImage originalSpriteImage = sprite2Image.Convert(parameters.ReferenceCell)
             .CreateFullImage(parameters.Palettes, true);
 
-        ImageSegment2IndexedImage segment2Indexed = new ImageSegment2IndexedImage();
-        segment2Indexed.Initialize(new ImageSegment2IndexedImageParams {
+        ImageSegment2IndexedImage segment2Indexed = new ImageSegment2IndexedImage(new ImageSegment2IndexedImageParams {
             FullImage = parameters.Image,
             IsTiled = parameters.IsImageTiled,
         });

--- a/src/Texim.Games/Raw/Exporter.cs
+++ b/src/Texim.Games/Raw/Exporter.cs
@@ -36,21 +36,21 @@ namespace Texim.Games.Raw
             string palettePath = Path.Combine(inputPath, config.Palette.Path);
             var paletteParams = config.Palette.GetParams();
             var paletteNode = NodeFactory.FromFile(palettePath, FileOpenMode.Read)
-                .TransformWith<RawBinary2PaletteCollection, RawPaletteParams>(paletteParams);
+                .TransformWith(new RawBinary2PaletteCollection(paletteParams));
 
             string pixelsPath = Path.Combine(inputPath, config.Pixels.Path);
             var pixelsParams = config.Pixels.GetParams();
             var pixelsNode = NodeFactory.FromFile(pixelsPath, FileOpenMode.Read)
-                .TransformWith<RawBinary2IndexedImage, RawIndexedImageParams>(pixelsParams);
+                .TransformWith(new RawBinary2IndexedImage(pixelsParams));
 
             string mapPath = Path.Combine(inputPath, config.Map.Path);
             var mapParams = config.Map.GetParams();
             var mapNode = NodeFactory.FromFile(mapPath, FileOpenMode.Read)
-                .TransformWith<RawBinary2ScreenMap, RawScreenMapParams>(mapParams);
+                .TransformWith(new RawBinary2ScreenMap(mapParams));
 
             if (config.Pixels.MissingBgTile) {
                 var newImage = AppendBackgroundTile(pixelsNode.GetFormatAs<IndexedImage>());
-                pixelsNode.ChangeFormat(newImage);
+                _ = pixelsNode.ChangeFormat(newImage);
             }
 
             string outputFilePath = Path.Combine(outputPath, config.Image);
@@ -61,8 +61,8 @@ namespace Texim.Games.Raw
             var indexedImageParams = new IndexedImageBitmapParams {
                 Palettes = paletteNode.GetFormatAs<PaletteCollection>(),
             };
-            pixelsNode.TransformWith<MapDecompression, MapDecompressionParams>(decompressionParams)
-                .TransformWith<IndexedImage2Bitmap, IndexedImageBitmapParams>(indexedImageParams)
+            pixelsNode.TransformWith(new MapDecompression(decompressionParams))
+                .TransformWith(new IndexedImage2Bitmap(indexedImageParams))
                 .Stream.WriteTo(outputFilePath);
         }
 

--- a/src/Texim.Tool/DarkoCommandLine.cs
+++ b/src/Texim.Tool/DarkoCommandLine.cs
@@ -78,7 +78,7 @@ public static class DarkoCommandLine
         var quantization = new FixedPaletteQuantization(palette);
         var bitmapNode = NodeFactory.FromFile(output, FileOpenMode.Read)
             .TransformWith<Bitmap2FullImage>()
-            .TransformWith<FullImage2IndexedPalette, IQuantization>(quantization);
+            .TransformWith(new FullImage2IndexedPalette(quantization));
         var newPixels = bitmapNode.GetFormatAs<IIndexedImage>().Pixels;
 
         using var newStream = new DataStream();

--- a/src/Texim.Tool/DevilSurvivorCommandLine.cs
+++ b/src/Texim.Tool/DevilSurvivorCommandLine.cs
@@ -63,7 +63,7 @@ namespace Texim.Tool
             };
             NodeFactory.FromFile(image, FileOpenMode.Read)
                 .TransformWith<DsTex2Image>()
-                .TransformWith<IndexedImage2Bitmap, IndexedImageBitmapParams>(exporterParameters)
+                .TransformWith(new IndexedImage2Bitmap(exporterParameters))
                 .Stream.WriteTo(output);
         }
 
@@ -77,7 +77,7 @@ namespace Texim.Tool
             };
             NodeFactory.FromFile(image, FileOpenMode.Read)
                 .TransformWith<Bitmap2FullImage>()
-                .TransformWith<FullImage2IndexedPalette, IQuantization>(quantization)
+                .TransformWith(new FullImage2IndexedPalette(quantization))
                 .TransformWith<DsTex2Image>()
                 .Stream.WriteTo(output);
         }

--- a/src/Texim.Tool/JumpUltimateStarsCommandLine.cs
+++ b/src/Texim.Tool/JumpUltimateStarsCommandLine.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 SceneGate
+// Copyright (c) 2021 SceneGate
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -90,8 +90,8 @@ namespace Texim.Tool
                    Palettes = image,
                 };
                 new Node("sprite", sprite)
-                    .TransformWith<Sprite2IndexedImage, Sprite2IndexedImageParams>(spriteParams)
-                    .TransformWith<IndexedImage2Bitmap, IndexedImageBitmapParams>(indexedImageParams)
+                    .TransformWith(new Sprite2IndexedImage(spriteParams))
+                    .TransformWith(new IndexedImage2Bitmap(indexedImageParams))
                     .Stream.WriteTo(outputFilePath);
             }
 

--- a/src/Texim.Tool/MegamanCommandLine.cs
+++ b/src/Texim.Tool/MegamanCommandLine.cs
@@ -67,8 +67,8 @@ public static class MegamanCommandLine
             string name = animation.Name;
             foreach (var frame in animation.Children) {
                 string outputFile = Path.Combine(output, name, $"{frame.Name}.png");
-                frame.TransformWith<Sprite2IndexedImage, Sprite2IndexedImageParams>(spriteParams)
-                    .TransformWith<IndexedImage2Bitmap, IndexedImageBitmapParams>(bitmapParams)
+                frame.TransformWith(new Sprite2IndexedImage(spriteParams))
+                    .TransformWith(new IndexedImage2Bitmap(bitmapParams))
                     .Stream.WriteTo(outputFile);
             }
         }

--- a/src/Texim.Tool/MetalMaxCommandLine.cs
+++ b/src/Texim.Tool/MetalMaxCommandLine.cs
@@ -58,7 +58,7 @@ namespace Texim.Tool
             var parameters = new IndexedImageBitmapParams {
                 Palette = node.GetFormatAs<MmTex>(),
             };
-            node.TransformWith<IndexedImage2Bitmap, IndexedImageBitmapParams>(parameters)
+            node.TransformWith(new IndexedImage2Bitmap(parameters))
                 .Stream.WriteTo(output);
         }
 
@@ -71,7 +71,7 @@ namespace Texim.Tool
             var quantization = new FixedPaletteQuantization(originalTex);
             using var newNode = NodeFactory.FromFile(input, FileOpenMode.Read)
                 .TransformWith<Bitmap2FullImage>()
-                .TransformWith<FullImage2IndexedPalette, IQuantization>(quantization);
+                .TransformWith(new FullImage2IndexedPalette(quantization));
 
             IIndexedImage newImage = newNode.GetFormatAs<IIndexedImage>();
             var newMmtex = new MmTex {

--- a/src/Texim.Tool/NitroCommandLine.cs
+++ b/src/Texim.Tool/NitroCommandLine.cs
@@ -194,14 +194,14 @@ namespace Texim.Tool
                     .GetFormatAs<Nscr>();
 
                 var mapParams = new MapDecompressionParams { Map = map };
-                _ = pixels.TransformWith<MapDecompression, MapDecompressionParams>(mapParams);
+                _ = pixels.TransformWith(new MapDecompression(mapParams));
             }
 
             var indexedParams = new IndexedImageBitmapParams {
                 Palettes = palette,
                 Encoder = format.GetEncoder(),
             };
-            pixels.TransformWith<IndexedImage2Bitmap, IndexedImageBitmapParams>(indexedParams)
+            pixels.TransformWith(new IndexedImage2Bitmap(indexedParams))
                 .Stream.WriteTo(output);
         }
 
@@ -246,8 +246,8 @@ namespace Texim.Tool
                 }
 
                 string outputImage = Path.Combine(output, sprite.Name + ".png");
-                sprite.TransformWith<Sprite2IndexedImage, Sprite2IndexedImageParams>(spriteParams)
-                    .TransformWith<IndexedImage2Bitmap, IndexedImageBitmapParams>(indexedParams)
+                sprite.TransformWith(new Sprite2IndexedImage(spriteParams))
+                    .TransformWith(new IndexedImage2Bitmap(indexedParams))
                     .Stream!.WriteTo(outputImage);
             }
         }
@@ -261,7 +261,7 @@ namespace Texim.Tool
             var quantization = new FixedPaletteQuantization(palette.Palettes[paletteIndex]);
             var newPixels = NodeFactory.FromFile(input, FileOpenMode.Read)
                 .TransformWith<Bitmap2FullImage>()
-                .TransformWith<FullImage2IndexedPalette, IQuantization>(quantization)
+                .TransformWith(new FullImage2IndexedPalette(quantization))
                 .GetFormatAs<IndexedImage>();
 
             Ncgr newNcgr;
@@ -332,7 +332,7 @@ namespace Texim.Tool
 
             var compressed = NodeFactory.FromFile(input, FileOpenMode.Read)
                 .TransformWith<Bitmap2FullImage>()
-                .TransformWith<FullImageMapCompression, FullImageMapCompressionParams>(compressionParams);
+                .TransformWith(new FullImageMapCompression(compressionParams));
             var newImage = compressed.Children[0].GetFormatAs<IndexedImage>();
             var map = compressed.Children[1].GetFormatAs<ScreenMap>();
 
@@ -408,8 +408,7 @@ namespace Texim.Tool
                 PixelSequences = uniqueTileSequences,
                 Image = image,
             };
-            var cellImageUpdater = new SpriteImageUpdater();
-            cellImageUpdater.Initialize(cellImageUpdaterParameters);
+            var cellImageUpdater = new SpriteImageUpdater(cellImageUpdaterParameters);
 
             for (int cellIndex = 0; cellIndex < numSprites; cellIndex++) {
                 string cellPath = Path.Combine(input, $"cell{cellIndex:D3}.png");
@@ -426,7 +425,7 @@ namespace Texim.Tool
 
                     using var sprite = NodeFactory.FromFile(cellPath, FileOpenMode.Read)
                         .TransformWith<Bitmap2FullImage>()
-                        .TransformWith<FullImage2NitroCell, FullImage2NitroCellParams>(cellConverterParameters);
+                        .TransformWith(new FullImage2NitroCell(cellConverterParameters));
                     var newCell = sprite.GetFormatAs<Cell>()!;
 
                     spriteCollectionNode.Children[cellIndex].ChangeFormat(newCell);

--- a/src/Texim/Compressions/Nitro/FullImageMapCompression.cs
+++ b/src/Texim/Compressions/Nitro/FullImageMapCompression.cs
@@ -21,28 +21,24 @@ namespace Texim.Compressions.Nitro
 {
     using System;
     using Texim.Images;
-    using Texim.Pixels;
     using Texim.Processing;
     using Yarhl.FileFormat;
     using Yarhl.FileSystem;
 
-    public class FullImageMapCompression :
-        IInitializer<FullImageMapCompressionParams>, IConverter<IFullImage, NodeContainerFormat>
+    public class FullImageMapCompression : IConverter<IFullImage, NodeContainerFormat>
     {
-        private FullImageMapCompressionParams parameters;
+        private readonly FullImageMapCompressionParams parameters;
 
-        public void Initialize(FullImageMapCompressionParams parameters)
+        public FullImageMapCompression(FullImageMapCompressionParams parameters)
         {
-            if (parameters == null)
-                throw new ArgumentNullException(nameof(parameters));
+            ArgumentNullException.ThrowIfNull(parameters);
 
             this.parameters = parameters;
         }
 
         public NodeContainerFormat Convert(IFullImage source)
         {
-            if (source == null)
-                throw new ArgumentNullException(nameof(source));
+            ArgumentNullException.ThrowIfNull(source);
 
             // TODO: Avoid several swizzling by providing an argument to quantization
             // and compression (in and out, out here too).
@@ -54,8 +50,7 @@ namespace Texim.Compressions.Nitro
 
             var fullIndexedImage = new IndexedImage(source.Width, source.Height, result.Pixels);
 
-            var compression = new MapCompression();
-            compression.Initialize(parameters);
+            var compression = new MapCompression(parameters);
             return compression.Convert(fullIndexedImage);
         }
     }

--- a/src/Texim/Compressions/Nitro/MapCompression.cs
+++ b/src/Texim/Compressions/Nitro/MapCompression.cs
@@ -27,13 +27,16 @@ namespace Texim.Compressions.Nitro
     using Yarhl.FileFormat;
     using Yarhl.FileSystem;
 
-    public class MapCompression :
-        IInitializer<MapCompressionParams>, IConverter<IIndexedImage, NodeContainerFormat>
+    public class MapCompression : IConverter<IIndexedImage, NodeContainerFormat>
     {
-        private System.Drawing.Size tileSize = new System.Drawing.Size(8, 8);
-        private IIndexedImage mergeImage;
+        private readonly System.Drawing.Size tileSize = new System.Drawing.Size(8, 8);
+        private readonly IIndexedImage mergeImage;
 
-        public void Initialize(MapCompressionParams parameters)
+        public MapCompression()
+        {
+        }
+
+        public MapCompression(MapCompressionParams parameters)
         {
             if (parameters == null)
                 throw new ArgumentNullException(nameof(parameters));

--- a/src/Texim/Compressions/Nitro/MapDecompression.cs
+++ b/src/Texim/Compressions/Nitro/MapDecompression.cs
@@ -25,15 +25,14 @@ namespace Texim.Compressions.Nitro
     using Yarhl.FileFormat;
 
     public class MapDecompression :
-        IInitializer<MapDecompressionParams>,
         IConverter<IIndexedImage, IndexedImage>,
         IConverter<IndexedPixel[], IndexedPixel[]>
     {
-        private System.Drawing.Size tileSize;
-        private IScreenMap map;
-        private int outOfBoundsIndex = -1;
+        private readonly System.Drawing.Size tileSize;
+        private readonly IScreenMap map;
+        private readonly int outOfBoundsIndex = -1;
 
-        public void Initialize(MapDecompressionParams parameters)
+        public MapDecompression(MapDecompressionParams parameters)
         {
             if (parameters == null)
                 throw new ArgumentNullException(nameof(parameters));
@@ -47,8 +46,6 @@ namespace Texim.Compressions.Nitro
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
-            if (map == null)
-                throw new InvalidOperationException("Missing initialization");
 
             // It's easier if we swizzle again, with the compressed tiles
             var swizzling = new TileSwizzling<IndexedPixel>(tileSize, source.Width);

--- a/src/Texim/Compressions/Nitro/RawBinary2ScreenMap.cs
+++ b/src/Texim/Compressions/Nitro/RawBinary2ScreenMap.cs
@@ -24,17 +24,18 @@ namespace Texim.Compressions.Nitro
     using Yarhl.FileFormat;
     using Yarhl.IO;
 
-    public class RawBinary2ScreenMap :
-        IInitializer<RawScreenMapParams>, IConverter<IBinary, ScreenMap>
+    public class RawBinary2ScreenMap : IConverter<IBinary, ScreenMap>
     {
-        private RawScreenMapParams parameters = RawScreenMapParams.Default;
+        private readonly RawScreenMapParams parameters;
 
-        public void Initialize(RawScreenMapParams parameters)
+        public RawBinary2ScreenMap()
         {
-            if (parameters == null)
-                throw new ArgumentNullException(nameof(parameters));
+            parameters = RawScreenMapParams.Default;
+        }
 
-            this.parameters = parameters;
+        public RawBinary2ScreenMap(RawScreenMapParams parameters)
+        {
+            this.parameters = parameters ?? throw new ArgumentNullException(nameof(parameters));
         }
 
         public ScreenMap Convert(IBinary source)

--- a/src/Texim/Formats/FullImage2Bitmap.cs
+++ b/src/Texim/Formats/FullImage2Bitmap.cs
@@ -28,23 +28,25 @@ namespace Texim.Formats
     using Yarhl.FileFormat;
     using Yarhl.IO;
 
-    public class FullImage2Bitmap :
-        IInitializer<IImageEncoder>, IConverter<IFullImage, BinaryFormat>
+    public class FullImage2Bitmap : IConverter<IFullImage, BinaryFormat>
     {
-        private IImageEncoder encoder = new PngEncoder();
+        private readonly IImageEncoder encoder;
 
-        public void Initialize(IImageEncoder parameters)
+        public FullImage2Bitmap()
         {
-            if (parameters == null)
-                throw new ArgumentNullException(nameof(parameters));
+            encoder = new PngEncoder();
+        }
+
+        public FullImage2Bitmap(IImageEncoder parameters)
+        {
+            ArgumentNullException.ThrowIfNull(parameters);
 
             encoder = parameters;
         }
 
         public BinaryFormat Convert(IFullImage source)
         {
-            if (source == null)
-                throw new ArgumentNullException(nameof(source));
+            ArgumentNullException.ThrowIfNull(source);
 
             using var image = new Image<Rgba32>(source.Width, source.Height);
             for (int x = 0; x < source.Width; x++) {

--- a/src/Texim/Formats/IndexedImage2Bitmap.cs
+++ b/src/Texim/Formats/IndexedImage2Bitmap.cs
@@ -28,13 +28,11 @@ namespace Texim.Formats
     using Yarhl.IO;
     using SixRgb = SixLabors.ImageSharp.PixelFormats.Rgba32;
 
-    public class IndexedImage2Bitmap :
-        IInitializer<IndexedImageBitmapParams>,
-        IConverter<IIndexedImage, BinaryFormat>
+    public class IndexedImage2Bitmap : IConverter<IIndexedImage, BinaryFormat>
     {
-        private IndexedImageBitmapParams parameters;
+        private readonly IndexedImageBitmapParams parameters;
 
-        public void Initialize(IndexedImageBitmapParams parameters)
+        public IndexedImage2Bitmap(IndexedImageBitmapParams parameters)
         {
             ArgumentNullException.ThrowIfNull(parameters);
 
@@ -43,8 +41,7 @@ namespace Texim.Formats
 
         public BinaryFormat Convert(IIndexedImage source)
         {
-            if (source == null)
-                throw new ArgumentNullException(nameof(source));
+            ArgumentNullException.ThrowIfNull(source);
 
             // Preconvert to colors for faster iteration later
             static SixRgb[] PaletteToColors(IPalette pal) =>

--- a/src/Texim/Formats/Palette2BinaryRiff.cs
+++ b/src/Texim/Formats/Palette2BinaryRiff.cs
@@ -25,17 +25,21 @@ namespace Texim.Formats
     using Yarhl.FileFormat;
     using Yarhl.IO;
 
-    public class Palette2BinaryRiff :
-        IInitializer<bool>, IConverter<IPalette, BinaryFormat>
+    public class Palette2BinaryRiff : IConverter<IPalette, BinaryFormat>
     {
+        public Palette2BinaryRiff()
+        {
+            GimpCompatibility = false;
+        }
+
+        public Palette2BinaryRiff(bool gimpCompatibility)
+        {
+            GimpCompatibility = gimpCompatibility;
+        }
+
         public static int Version => 03_00;
 
         public bool GimpCompatibility { get; set; }
-
-        public void Initialize(bool parameters)
-        {
-            GimpCompatibility = parameters;
-        }
 
         public BinaryFormat Convert(IPalette source)
         {

--- a/src/Texim/Formats/Palette2Bitmap.cs
+++ b/src/Texim/Formats/Palette2Bitmap.cs
@@ -28,22 +28,26 @@ namespace Texim.Formats
     using Yarhl.FileFormat;
     using Yarhl.IO;
 
-    public class Palette2Bitmap :
-       IInitializer<IImageEncoder>, IConverter<IPalette, BinaryFormat>
+    public class Palette2Bitmap : IConverter<IPalette, BinaryFormat>
     {
         private const int ColorsPerRow = 16;
         private const int ZoomSize = 10;
-        private IImageEncoder encoder = new PngEncoder();
+        private readonly IImageEncoder encoder;
 
-        public void Initialize(IImageEncoder parameters)
+        public Palette2Bitmap()
         {
+            encoder = new PngEncoder();
+        }
+
+        public Palette2Bitmap(IImageEncoder parameters)
+        {
+            ArgumentNullException.ThrowIfNull(parameters);
             encoder = parameters;
         }
 
         public BinaryFormat Convert(IPalette source)
         {
-            if (source == null)
-                throw new ArgumentNullException(nameof(source));
+            ArgumentNullException.ThrowIfNull(source);
 
             var colors = source.Colors;
 

--- a/src/Texim/Formats/PaletteCollection2ContainerBitmap.cs
+++ b/src/Texim/Formats/PaletteCollection2ContainerBitmap.cs
@@ -26,25 +26,29 @@ namespace Texim.Formats
     using Yarhl.FileFormat;
     using Yarhl.FileSystem;
 
-    public class PaletteCollection2ContainerBitmap :
-        IInitializer<IImageEncoder>, IConverter<IPaletteCollection, NodeContainerFormat>
+    public class PaletteCollection2ContainerBitmap : IConverter<IPaletteCollection, NodeContainerFormat>
     {
-        private IImageEncoder encoder = new PngEncoder();
+        private readonly IImageEncoder encoder;
 
-        public void Initialize(IImageEncoder parameters)
+        public PaletteCollection2ContainerBitmap()
         {
+            encoder = new PngEncoder();
+        }
+
+        public PaletteCollection2ContainerBitmap(IImageEncoder parameters)
+        {
+            ArgumentNullException.ThrowIfNull(parameters);
             encoder = parameters;
         }
 
         public NodeContainerFormat Convert(IPaletteCollection source)
         {
-            if (source == null)
-                throw new ArgumentNullException(nameof(source));
+            ArgumentNullException.ThrowIfNull(source);
 
             var container = new NodeContainerFormat();
             for (int i = 0; i < source.Palettes.Count; i++) {
                 var child = new Node($"Palette {i}", source.Palettes[i])
-                    .TransformWith<Palette2Bitmap, IImageEncoder>(encoder);
+                    .TransformWith(new Palette2Bitmap(encoder));
                 container.Root.Add(child);
             }
 

--- a/src/Texim/Formats/RawBinary2IndexedImage.cs
+++ b/src/Texim/Formats/RawBinary2IndexedImage.cs
@@ -26,17 +26,18 @@ namespace Texim.Formats
     using Yarhl.FileFormat;
     using Yarhl.IO;
 
-    public class RawBinary2IndexedImage :
-        IInitializer<RawIndexedImageParams>, IConverter<IBinary, IndexedImage>
+    public class RawBinary2IndexedImage : IConverter<IBinary, IndexedImage>
     {
-        private RawIndexedImageParams parameters = RawIndexedImageParams.Default;
+        private readonly RawIndexedImageParams parameters;
 
-        public void Initialize(RawIndexedImageParams parameters)
+        public RawBinary2IndexedImage()
         {
-            if (parameters == null)
-                throw new ArgumentNullException(nameof(parameters));
+            parameters = RawIndexedImageParams.Default;
+        }
 
-            this.parameters = parameters;
+        public RawBinary2IndexedImage(RawIndexedImageParams parameters)
+        {
+            this.parameters = parameters ?? throw new ArgumentNullException(nameof(parameters));
         }
 
         public IndexedImage Convert(IBinary source)

--- a/src/Texim/Formats/RawBinary2PaletteCollection.cs
+++ b/src/Texim/Formats/RawBinary2PaletteCollection.cs
@@ -25,17 +25,18 @@ namespace Texim.Formats
     using Yarhl.FileFormat;
     using Yarhl.IO;
 
-    public class RawBinary2PaletteCollection :
-        IInitializer<RawPaletteParams>, IConverter<BinaryFormat, PaletteCollection>
+    public class RawBinary2PaletteCollection : IConverter<BinaryFormat, PaletteCollection>
     {
-        private RawPaletteParams parameters = RawPaletteParams.Default;
+        private readonly RawPaletteParams parameters;
 
-        public void Initialize(RawPaletteParams parameters)
+        public RawBinary2PaletteCollection()
         {
-            if (parameters == null)
-                throw new ArgumentNullException(nameof(parameters));
+            parameters = RawPaletteParams.Default;
+        }
 
-            this.parameters = parameters;
+        public RawBinary2PaletteCollection(RawPaletteParams parameters)
+        {
+            this.parameters = parameters ?? throw new ArgumentNullException(nameof(parameters));
         }
 
         public PaletteCollection Convert(BinaryFormat source)

--- a/src/Texim/Formats/Sprite2Tiff.cs
+++ b/src/Texim/Formats/Sprite2Tiff.cs
@@ -85,8 +85,7 @@ public class Sprite2Tiff : IConverter<ISprite, TiffImage>
             }
         }
 
-        var sprite2Image = new Sprite2IndexedImage();
-        sprite2Image.Initialize(new Sprite2IndexedImageParams {
+        var sprite2Image = new Sprite2IndexedImage(new Sprite2IndexedImageParams {
             FullImage = parameters.Image,
             IsTiled = parameters.IsTiled,
             TileSize = parameters.TileSize,

--- a/src/Texim/Images/FullImage2IndexedPalette.cs
+++ b/src/Texim/Images/FullImage2IndexedPalette.cs
@@ -20,17 +20,14 @@
 namespace Texim.Images
 {
     using System;
-    using Texim.Palettes;
-    using Texim.Pixels;
     using Texim.Processing;
     using Yarhl.FileFormat;
 
-    public class FullImage2IndexedPalette :
-        IInitializer<IQuantization>, IConverter<IFullImage, IndexedPaletteImage>
+    public class FullImage2IndexedPalette : IConverter<IFullImage, IndexedPaletteImage>
     {
-        private IQuantization quantization;
+        private readonly IQuantization quantization;
 
-        public void Initialize(IQuantization parameters)
+        public FullImage2IndexedPalette(IQuantization parameters)
         {
             quantization = parameters ?? throw new ArgumentNullException(nameof(parameters));
         }

--- a/src/Texim/Images/Indexed2FullImage.cs
+++ b/src/Texim/Images/Indexed2FullImage.cs
@@ -25,49 +25,36 @@ namespace Texim.Images
     using Texim.Pixels;
     using Yarhl.FileFormat;
 
-    public class Indexed2FullImage :
-        IInitializer<IPalette>,
-        IInitializer<IPaletteCollection>,
-        IInitializer<(IPaletteCollection Palettes, bool FirstColorAsTransparent)>,
-        IConverter<IIndexedImage, FullImage>
+    public class Indexed2FullImage : IConverter<IIndexedImage, FullImage>
     {
-        private readonly PaletteCollection palettes = new PaletteCollection();
-        private bool firstColorAsTransparent;
+        private readonly PaletteCollection palettes;
+        private readonly bool firstColorAsTransparent;
 
-        public void Initialize(IPalette parameters)
+        public Indexed2FullImage(IPalette palette)
         {
-            if (parameters == null)
-                throw new ArgumentNullException(nameof(parameters));
-
+            ArgumentNullException.ThrowIfNull(palette);
             firstColorAsTransparent = false;
-            palettes.Palettes.Clear();
-            palettes.Palettes.Add(parameters);
+            palettes = new PaletteCollection(palette);
         }
 
-        public void Initialize(IPaletteCollection parameters)
+        public Indexed2FullImage(IPaletteCollection palettes)
         {
-            if (parameters == null)
-                throw new ArgumentNullException(nameof(parameters));
-
+            ArgumentNullException.ThrowIfNull(palettes);
             firstColorAsTransparent = false;
-            palettes.Palettes.Clear();
-            palettes.Palettes.Add(parameters.Palettes);
+            this.palettes = new PaletteCollection(palettes.Palettes);
         }
 
-        public void Initialize((IPaletteCollection Palettes, bool FirstColorAsTransparent) parameters)
+        public Indexed2FullImage(IPaletteCollection palettes, bool firstColorAsTransparent)
         {
-            ArgumentNullException.ThrowIfNull(parameters);
-            ArgumentNullException.ThrowIfNull(parameters.Palettes);
+            ArgumentNullException.ThrowIfNull(palettes);
 
-            palettes.Palettes.Clear();
-            palettes.Palettes.Add(parameters.Palettes.Palettes);
-            firstColorAsTransparent = parameters.FirstColorAsTransparent;
+            this.palettes = new PaletteCollection(palettes.Palettes);
+            this.firstColorAsTransparent = firstColorAsTransparent;
         }
 
         public FullImage Convert(IIndexedImage source)
         {
-            if (source == null)
-                throw new ArgumentNullException(nameof(source));
+            ArgumentNullException.ThrowIfNull(source);
 
             var image = new FullImage(source.Width, source.Height);
             for (int i = 0; i < source.Pixels.Length; i++) {

--- a/src/Texim/Images/IndexedImage.cs
+++ b/src/Texim/Images/IndexedImage.cs
@@ -25,8 +25,6 @@ namespace Texim.Images
 
     public class IndexedImage : IIndexedImage
     {
-        private static Indexed2FullImage fullImageConverter = new Indexed2FullImage();
-
         public IndexedImage()
         {
         }
@@ -53,19 +51,19 @@ namespace Texim.Images
 
         public FullImage CreateFullImage(IPalette palette)
         {
-            fullImageConverter.Initialize(palette);
+            var fullImageConverter = new Indexed2FullImage(palette);
             return fullImageConverter.Convert(this);
         }
 
         public FullImage CreateFullImage(IPaletteCollection palettes)
         {
-            fullImageConverter.Initialize(palettes);
+            var fullImageConverter = new Indexed2FullImage(palettes);
             return fullImageConverter.Convert(this);
         }
 
         public FullImage CreateFullImage(IPaletteCollection palettes, bool firstColorAsTransparent)
         {
-            fullImageConverter.Initialize((palettes, firstColorAsTransparent));
+            var fullImageConverter = new Indexed2FullImage(palettes, firstColorAsTransparent);
             return fullImageConverter.Convert(this);
         }
     }

--- a/src/Texim/Images/IndexedPaletteImage.cs
+++ b/src/Texim/Images/IndexedPaletteImage.cs
@@ -25,8 +25,6 @@ namespace Texim.Images
 
     public class IndexedPaletteImage : IIndexedImage, IPaletteCollection
     {
-        private static Indexed2FullImage fullImageConverter = new Indexed2FullImage();
-
         public int Width { get; init; }
 
         public int Height { get; init; }
@@ -37,7 +35,7 @@ namespace Texim.Images
 
         public FullImage CreateFullImage()
         {
-            fullImageConverter.Initialize(this);
+            var fullImageConverter = new Indexed2FullImage(this);
             return fullImageConverter.Convert(this);
         }
     }

--- a/src/Texim/Sprites/FullImage2Sprite.cs
+++ b/src/Texim/Sprites/FullImage2Sprite.cs
@@ -28,17 +28,15 @@ using Texim.Pixels;
 using Texim.Processing;
 using Yarhl.FileFormat;
 
-public class FullImage2Sprite :
-    IInitializer<FullImage2SpriteParams>,
-    IConverter<FullImage, ISprite>
+public class FullImage2Sprite : IConverter<FullImage, ISprite>
 {
-    protected FullImage2SpriteParams Parameters { get; private set; }
-
-    public void Initialize(FullImage2SpriteParams parameters)
+    public FullImage2Sprite(FullImage2SpriteParams parameters)
     {
         ArgumentNullException.ThrowIfNull(parameters);
         Parameters = parameters;
     }
+
+    protected FullImage2SpriteParams Parameters { get; private set; }
 
     public virtual ISprite Convert(FullImage source)
     {

--- a/src/Texim/Sprites/ImageSegment2IndexedImage.cs
+++ b/src/Texim/Sprites/ImageSegment2IndexedImage.cs
@@ -24,23 +24,19 @@ using Texim.Images;
 using Texim.Pixels;
 using Yarhl.FileFormat;
 
-public class ImageSegment2IndexedImage :
-    IInitializer<ImageSegment2IndexedImageParams>,
-    IConverter<IImageSegment, IndexedImage>
+public class ImageSegment2IndexedImage : IConverter<IImageSegment, IndexedImage>
 {
-    private ImageSegment2IndexedImageParams parameters;
+    private readonly ImageSegment2IndexedImageParams parameters;
 
-    public void Initialize(ImageSegment2IndexedImageParams parameters)
+    public ImageSegment2IndexedImage(ImageSegment2IndexedImageParams parameters)
     {
+        ArgumentNullException.ThrowIfNull(parameters);
         this.parameters = parameters;
     }
 
     public IndexedImage Convert(IImageSegment source)
     {
-        if (source is null)
-            throw new ArgumentNullException(nameof(source));
-        if (parameters is null)
-            throw new InvalidOperationException("Missing initialization");
+        ArgumentNullException.ThrowIfNull(source);
 
         // If it was tiled swizzled, then convert to tiles so we can resolve the references
         IndexedPixel[] tiles = parameters.FullImage.Pixels;

--- a/src/Texim/Sprites/Sprite2IndexedImage.cs
+++ b/src/Texim/Sprites/Sprite2IndexedImage.cs
@@ -25,14 +25,12 @@ using Texim.Images;
 using Texim.Pixels;
 using Yarhl.FileFormat;
 
-public class Sprite2IndexedImage :
-    IInitializer<Sprite2IndexedImageParams>,
-    IConverter<ISprite, IndexedImage>
+public class Sprite2IndexedImage : IConverter<ISprite, IndexedImage>
 {
-    private readonly ImageSegment2IndexedImage segmentConverter = new();
-    private Sprite2IndexedImageParams parameters;
+    private readonly ImageSegment2IndexedImage segmentConverter;
+    private readonly Sprite2IndexedImageParams parameters;
 
-    public void Initialize(Sprite2IndexedImageParams parameters)
+    public Sprite2IndexedImage(Sprite2IndexedImageParams parameters)
     {
         this.parameters = parameters;
 
@@ -42,15 +40,13 @@ public class Sprite2IndexedImage :
             OutOfBoundsTileIndex = parameters.OutOfBoundsTileIndex,
             IsTiled = parameters.IsTiled,
         };
-        segmentConverter.Initialize(segmentParams);
+        segmentConverter = new ImageSegment2IndexedImage(segmentParams);
     }
 
     public IndexedImage Convert(ISprite source)
     {
         if (source is null)
             throw new ArgumentNullException(nameof(source));
-        if (parameters is null)
-            throw new InvalidOperationException("Missing initialization");
 
         var pixels = new IndexedPixel[source.Width * source.Height];
         Span<IndexedPixel> pixelsSpan = pixels;

--- a/src/Texim/Sprites/SpriteImageUpdater.cs
+++ b/src/Texim/Sprites/SpriteImageUpdater.cs
@@ -26,13 +26,11 @@ using System.Runtime.InteropServices;
 using Texim.Pixels;
 using Yarhl.FileFormat;
 
-public class SpriteImageUpdater :
-    IInitializer<SpriteImageUpdaterParams>,
-    IConverter<ISprite, ISprite>
+public class SpriteImageUpdater : IConverter<ISprite, ISprite>
 {
-    private SpriteImageUpdaterParams parameters;
+    private readonly SpriteImageUpdaterParams parameters;
 
-    public void Initialize(SpriteImageUpdaterParams parameters)
+    public SpriteImageUpdater(SpriteImageUpdaterParams parameters)
     {
         ArgumentNullException.ThrowIfNull(parameters);
         this.parameters = parameters;


### PR DESCRIPTION
### Description

Migrate converters initializers to constructors.
Also bump all the dependencies.